### PR TITLE
fix: #76 GitHubイベントの取り込みで一意性制約違反にならないように修正

### DIFF
--- a/src/main/services/GitHubEventStoreServiceImpl.ts
+++ b/src/main/services/GitHubEventStoreServiceImpl.ts
@@ -33,6 +33,15 @@ export class GitHubEventStoreServiceImpl implements IGitHubEventStoreService {
     );
   }
 
+  async findById(ids: string[]): Promise<GitHubEvent[]> {
+    const userId = await this.userDetailsService.getUserId();
+    return await this.dataSource.find(
+      this.tableName,
+      { id: { $in: ids }, minr_user_id: userId },
+      { updated_at: -1 }
+    );
+  }
+
   async save(data: GitHubEvent): Promise<GitHubEvent> {
     return await this.dataSource.upsert(this.tableName, data);
   }

--- a/src/main/services/IGitHubEventStoreService.ts
+++ b/src/main/services/IGitHubEventStoreService.ts
@@ -2,5 +2,6 @@ import { GitHubEvent } from '@shared/dto/GitHubEvent';
 
 export interface IGitHubEventStoreService {
   list(startDate: Date, endDate: Date): Promise<GitHubEvent[]>;
+  findById(ids: string[]): Promise<GitHubEvent[]>;
   save(event: GitHubEvent): Promise<GitHubEvent>;
 }


### PR DESCRIPTION
Issue: #76

既存の登録確認を、日付を指定して既存のデータを読み込んで、比較するようにしていたが、
既存のテストデータの問題か、あるいは、GitHubのイベントの日付の仕様がよくわかっていなくて、
正しい実装になっていないため、IDを指定して既存のデータを検索して比較するように修正。