### PR TITLE
feat: #48 Googleカレンダー同期によるイベント更新をサブスクライブする

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,7 +35,7 @@ if (!gotTheLock) {
   }
 
   const taskScheduler = mainContainer.get<TaskScheduler>(TYPES.TaskScheduler);
-  const watcher = mainContainer.get<ITaskProcessor>(TYPES.WindowWatcher);
+  const watcher = mainContainer.get<ITaskProcessor>(TYPES.WindowWatchProcessor);
   taskScheduler.addTaskProcessor(watcher, 1 * 60 * 1000);
   const calendarSync = mainContainer.get<ITaskProcessor>(TYPES.CalendarSyncProcessor);
   taskScheduler.addTaskProcessor(calendarSync, 5 * 60 * 1000);

--- a/src/main/inversify.config.ts
+++ b/src/main/inversify.config.ts
@@ -20,7 +20,7 @@ import { DataSource } from './services/DataSource';
 import { IEventEntryService } from './services/IEventEntryService';
 import { EventEntryServiceImpl } from './services/EventEntryServiceImpl';
 import { EventEntryServiceHandlerImpl } from './ipc/EventEntryServiceHandlerImpl';
-import { WindowWatcher } from './services/WindowWatcher';
+import { WindowWatchProcessorImpl } from './services/WindowWatchProcessorImpl';
 import { IWindowLogService } from './services/IWindowLogService';
 import { WindowLogServiceImpl } from './services/WindowLogServiceImpl';
 import { ActivityServiceHandlerImpl } from './ipc/ActivityServiceHandlerImpl';
@@ -164,7 +164,10 @@ container
 }
 
 // アクティブWindowのウォッチャーのバインド
-container.bind<WindowWatcher>(TYPES.WindowWatcher).to(WindowWatcher).inSingletonScope();
+container
+  .bind<WindowWatchProcessorImpl>(TYPES.WindowWatchProcessor)
+  .to(WindowWatchProcessorImpl)
+  .inSingletonScope();
 // DBのバインド
 container.bind(TYPES.DataSource).to(DataSource).inSingletonScope();
 

--- a/src/main/services/WindowWatchProcessorImpl.ts
+++ b/src/main/services/WindowWatchProcessorImpl.ts
@@ -20,7 +20,7 @@ import { IpcChannel } from '@shared/constants';
  * 当面は renderer プロセスからのポーリングで実装する
  */
 @injectable()
-export class WindowWatcher implements ITaskProcessor {
+export class WindowWatchProcessorImpl implements ITaskProcessor {
   private currWinlog: WindowLog | null = null;
   private currActivity: ActivityEvent | null = null;
   private winTimer: NodeJS.Timer | null = null;
@@ -117,7 +117,7 @@ export class WindowWatcher implements ITaskProcessor {
         this.currActivity = await this.activityService.createActivityEvent(this.currWinlog);
         updateEvents.push(this.currActivity);
       }
-      console.log('fire ACTIVITY_NOTIFY');
+      console.log('send ACTIVITY_NOTIFY');
       this.ipcService.send(IpcChannel.ACTIVITY_NOTIFY);
     }
   }

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -33,7 +33,7 @@ export const TYPES = {
   IpcHandlerInitializer: Symbol.for('IpcHandlerInitializer'),
   SystemIdleService: Symbol.for('SystemIdleService'),
   // infrastracture/windowlog
-  WindowWatcher: Symbol.for('WindowWatcher'),
+  WindowWatchProcessor: Symbol.for('WindowWatcher'),
   // infrastracture/DB
   DataSource: Symbol.for('DataSource'),
 

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -81,6 +81,20 @@ const TimeTable = (): JSX.Element => {
     };
   }, [refreshActivityEntries]);
 
+  useEffect(() => {
+    // ハンドラ
+    const handler = (): void => {
+      console.log('recv EVENT_ENTRY_NOTIFY');
+      refreshEventEntries();
+    };
+    // コンポーネントがマウントされたときに IPC のハンドラを設定
+    const unsubscribe = window.electron.ipcRenderer.on(IpcChannel.EVENT_ENTRY_NOTIFY, handler);
+    // コンポーネントがアンマウントされたときに解除
+    return () => {
+      unsubscribe();
+    };
+  }, [refreshEventEntries]);
+
   if (eventEntries === null || activityEvents === null) {
     return <div>Loading...</div>;
   }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -29,6 +29,7 @@ export enum IpcChannel {
 
   SPEAK_TEXT_NOTIFY = 'speak_text_notify',
   ACTIVITY_NOTIFY = 'activity_notify',
+  EVENT_ENTRY_NOTIFY = 'event_entry_notify',
 }
 
 export const LOCAL_USER_ID = 'LOCAL_USER_ID';


### PR DESCRIPTION
Issue: #48

イベントの表示はもともとポーリング方式ではなくイベントの登録更新のタイミングで
最新データの取り直しが行われていたので、サブスクライブするのは、Googleカレンダーで
更新されたデータがあったときだけでよかった。