### PR TITLE
D&Dで異常なデータ登録がなくなるように修正

### DIFF
--- a/src/main/ipc/EventEntryServiceHandlerImpl.ts
+++ b/src/main/ipc/EventEntryServiceHandlerImpl.ts
@@ -70,14 +70,7 @@ export class EventEntryServiceHandlerImpl implements IIpcHandlerInitializer {
      * lastSynced を更新して、同期処理の対象となるようにする。
      */
     ipcMain.handle(IpcChannel.EVENT_ENTRY_DELETE, async (_event, id: string) => {
-      const eventEntry = await this.eventEntryService.get(id);
-      if (eventEntry) {
-        eventEntry.deleted = new Date();
-        if (eventEntry.externalEventEntryId) {
-          eventEntry.lastSynced = eventEntry.deleted;
-        }
-        await this.eventEntryService.save(eventEntry);
-      }
+      await this.eventEntryService.logicalDelete(id);
     });
   }
 }

--- a/src/main/services/CalendarSyncProcessorImpl.ts
+++ b/src/main/services/CalendarSyncProcessorImpl.ts
@@ -180,6 +180,9 @@ export class CalendarSyncProcessorImpl implements ITaskProcessor {
     }
     for (const minrEvent of minrEventsMap.values()) {
       if (minrEvent.externalEventEntryId) {
+        if (minrEvent.deleted) {
+          continue;
+        }
         await this.deleteMinrEvent(minrEvent);
         updateCount++;
       } else if (!minrEvent.externalEventEntryId) {
@@ -203,13 +206,13 @@ export class CalendarSyncProcessorImpl implements ITaskProcessor {
   }
 
   private async updateMinrEvent(minr: EventEntry, external: ExternalEventEntry): Promise<void> {
-    console.log('updateMinrEvent', minr, external);
+    console.log('updateMinrEvent', minr.id, minr, external);
     EventEntryFactory.updateFromExternal(minr, external);
     await this.eventEntryService.save(minr);
   }
 
   private async deleteMinrEvent(minr: EventEntry): Promise<void> {
-    console.log('deleteMinrEvent', minr);
+    console.log('deleteMinrEvent', minr.id, minr);
     EventEntryFactory.updateLogicalDelete(minr);
     await this.eventEntryService.save(minr);
   }
@@ -218,7 +221,7 @@ export class CalendarSyncProcessorImpl implements ITaskProcessor {
     calendarSetting: CalendarSetting,
     minr: EventEntry
   ): Promise<void> {
-    console.log('newExternalEvent', minr);
+    console.log('newExternalEvent', minr.id, minr);
     const external = ExternalEventEntryFactory.createFromMinr(minr, calendarSetting.calendarId);
     const updated = await this.externalCalendarService.saveEvent(external);
     EventEntryFactory.updateFromExternal(minr, updated);
@@ -226,7 +229,7 @@ export class CalendarSyncProcessorImpl implements ITaskProcessor {
   }
 
   private async updateExternalEvent(external: ExternalEventEntry, minr: EventEntry): Promise<void> {
-    console.log('updateExternalEvent', external, minr);
+    console.log('updateExternalEvent', minr.id, external, minr);
     ExternalEventEntryFactory.updateFromMinr(external, minr);
     const updated = await this.externalCalendarService.saveEvent(external);
     EventEntryFactory.updateFromExternal(minr, updated);

--- a/src/main/services/EventEntryFactory.ts
+++ b/src/main/services/EventEntryFactory.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { EVENT_TYPE, EventEntry } from '@shared/data/EventEntry';
 import { ExternalEventEntry } from '@shared/data/ExternalEventEntry';
+import { isBlank } from '@shared/utils/StrUtil';
 
 export class EventEntryFactory {
   static create(overlaps: Omit<EventEntry, 'id' | 'updated'>): EventEntry {
@@ -46,6 +47,35 @@ export class EventEntryFactory {
     minrEvent.deleted = deleted;
     if (minrEvent.externalEventEntryId) {
       minrEvent.lastSynced = deleted;
+    }
+  }
+
+  static validate(minrEvent: EventEntry): void {
+    if (isBlank(minrEvent.id)) {
+      throw new Error('id is blank');
+    }
+    if (isBlank(minrEvent.userId)) {
+      throw new Error('userId is blank');
+    }
+    if (isBlank(minrEvent.eventType)) {
+      throw new Error('eventType is blank');
+    }
+    if (isBlank(minrEvent.summary)) {
+      throw new Error('summary is blank');
+    }
+    if (!minrEvent.start.date && !minrEvent.start.dateTime) {
+      throw new Error('start is empty');
+    }
+    if (minrEvent.start.dateTime) {
+      if (!minrEvent.end.dateTime) {
+        throw new Error('end is empty');
+      }
+      if (minrEvent.start.dateTime.getTime() >= minrEvent.end.dateTime.getTime()) {
+        throw new Error('start is after end');
+      }
+    }
+    if (!minrEvent.updated) {
+      throw new Error('updated is empty');
     }
   }
 }

--- a/src/main/services/EventEntryFactory.ts
+++ b/src/main/services/EventEntryFactory.ts
@@ -43,7 +43,9 @@ export class EventEntryFactory {
 
   static updateLogicalDelete(minrEvent: EventEntry): void {
     const deleted = new Date();
-    minrEvent.lastSynced = deleted;
     minrEvent.deleted = deleted;
+    if (minrEvent.externalEventEntryId) {
+      minrEvent.lastSynced = deleted;
+    }
   }
 }

--- a/src/main/services/EventEntryServiceImpl.ts
+++ b/src/main/services/EventEntryServiceImpl.ts
@@ -33,6 +33,7 @@ export class EventEntryServiceImpl implements IEventEntryService {
 
   async save(data: EventEntry): Promise<EventEntry> {
     data.updated = new Date();
+    EventEntryFactory.validate(data);
     return await this.dataSource.upsert(this.tableName, data);
   }
 

--- a/src/main/services/EventEntryServiceImpl.ts
+++ b/src/main/services/EventEntryServiceImpl.ts
@@ -3,6 +3,7 @@ import { IEventEntryService } from './IEventEntryService';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '@main/types';
 import { DataSource } from './DataSource';
+import { EventEntryFactory } from './EventEntryFactory';
 
 @injectable()
 export class EventEntryServiceImpl implements IEventEntryService {
@@ -33,6 +34,15 @@ export class EventEntryServiceImpl implements IEventEntryService {
   async save(data: EventEntry): Promise<EventEntry> {
     data.updated = new Date();
     return await this.dataSource.upsert(this.tableName, data);
+  }
+
+  async logicalDelete(id: string): Promise<void> {
+    const eventEntry = await this.get(id);
+    if (!eventEntry) {
+      return;
+    }
+    EventEntryFactory.updateLogicalDelete(eventEntry);
+    await this.save(eventEntry);
   }
 
   async delete(id: string): Promise<void> {

--- a/src/main/services/IEventEntryService.ts
+++ b/src/main/services/IEventEntryService.ts
@@ -4,5 +4,6 @@ export interface IEventEntryService {
   list(userId: string, start: Date, end: Date): Promise<EventEntry[]>;
   get(id: string): Promise<EventEntry | undefined>;
   save(data: EventEntry): Promise<EventEntry>;
+  logicalDelete(id: string): Promise<void>;
   delete(id: string): Promise<void>;
 }

--- a/src/main/services/__tests__/__mocks__/EventEntryServiceMockBuilder.ts
+++ b/src/main/services/__tests__/__mocks__/EventEntryServiceMockBuilder.ts
@@ -8,6 +8,7 @@ export class EventEntryServiceMockBuilder {
   > = jest.fn();
   private get: jest.MockedFunction<(id: string) => Promise<EventEntry | undefined>> = jest.fn();
   private save: jest.MockedFunction<(data: EventEntry) => Promise<EventEntry>> = jest.fn();
+  private logicalDelete: jest.MockedFunction<(id: string) => Promise<void>> = jest.fn();
   private delete: jest.MockedFunction<(id: string) => Promise<void>> = jest.fn();
 
   constructor() {
@@ -39,6 +40,7 @@ export class EventEntryServiceMockBuilder {
       list: this.list,
       get: this.get,
       save: this.save,
+      logicalDelete: this.logicalDelete,
       delete: this.delete,
     };
     return mock;

--- a/src/renderer/src/services/OverlapEventServiceImpl.ts
+++ b/src/renderer/src/services/OverlapEventServiceImpl.ts
@@ -11,10 +11,24 @@ import { EventTimeCell } from './EventTimeCell';
 @injectable()
 export class OverlapEventServiceImpl implements IOverlapEventService {
   execute(eventTimeCells: ReadonlyArray<EventTimeCell>): EventTimeCell[] {
+    // console.log('OverlapEventServiceImpl.execute', eventTimeCells.length);
+
     // ソートして重なりをカウントする
     const sortedCells = [...eventTimeCells].sort(
       (a, b) => a.cellFrameStart.getTime() - b.cellFrameStart.getTime()
     );
+    // sortedCells.forEach((cell) => {
+    //   const s = format(cell.cellFrameStart, 'HH:mm');
+    //   const e = format(cell.endTime, 'HH:mm');
+    //   const fe = format(cell.cellFrameEnd, 'HH:mm');
+    //   console.log(
+    //     'sort',
+    //     `${cell.summary}:`,
+    //     `${s} - ${fe} (${e})`,
+    //     `${cell.overlappingIndex}/${cell.overlappingCount}}`
+    //   );
+    // });
+
     // 同じ時間帯のイベントのグループ
     const cellGroups: EventTimeCell[][] = [];
     for (const eventCell of sortedCells) {
@@ -48,6 +62,17 @@ export class OverlapEventServiceImpl implements IOverlapEventService {
       }
     }
     this.reGrouping(cellGroups);
+    // sortedCells.forEach((cell) => {
+    //   const s = format(cell.cellFrameStart, 'HH:mm');
+    //   const e = format(cell.endTime, 'HH:mm');
+    //   const fe = format(cell.cellFrameEnd, 'HH:mm');
+    //   console.log(
+    //     'return',
+    //     `${cell.summary}:`,
+    //     `${s} - ${fe} (${e})`,
+    //     `${cell.overlappingIndex}/${cell.overlappingCount}}`
+    //   );
+    // });
     return sortedCells;
   }
 

--- a/src/renderer/src/services/__tests__/OverlapEventServiceImpl.test.ts
+++ b/src/renderer/src/services/__tests__/OverlapEventServiceImpl.test.ts
@@ -15,294 +15,296 @@ describe('OverlapEventServiceImpl', () => {
   };
 
   test.each([
-    // [
-    //   'empty なイベント',
-    //   [],
-    //   (result): void => {
-    //     expect(result).toEqual([]);
-    //   },
-    // ],
-    // [
-    //   '1つのイベント',
-    //   [eventTimeCellFixture(EventEntryFixture.default())],
-    //   (result): void => {
-    //     expect(result[0].overlappingIndex).toBe(0);
-    //     expect(result[0].overlappingCount).toBe(1);
-    //   },
-    // ],
-    // [
-    //   '部分的に重なるイベント(1)',
-    //   // 10:00  +------+
-    //   //        |event1|
-    //   // 10:30  |      | +------+
-    //   //        |      | |event2|
-    //   // 11:00  +------+ |      |
-    //   //                 |      |
-    //   // 11:30           +------+
-    //   [
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event1',
-    //         start: { dateTime: new Date('2023-07-01T10:00:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T11:00:00+0900') },
-    //       })
-    //     ),
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event2',
-    //         start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T11:30:00+0900') },
-    //       })
-    //     ),
-    //   ],
-    //   (result): void => {
-    //     expect(result.length).toBe(2);
-    //     {
-    //       const actual = result[0];
-    //       expect(actual.overlappingIndex).toBe(0);
-    //       expect(actual.overlappingCount).toBe(2);
-    //     }
-    //     {
-    //       const actual = result[1];
-    //       expect(actual.overlappingIndex).toBe(1);
-    //       expect(actual.overlappingCount).toBe(2);
-    //     }
-    //   },
-    // ],
-    // [
-    //   '部分的に重なるイベント(2)',
-    //   // 10:00           +------+
-    //   //                 |event2|
-    //   // 10:30  +------+ |      |
-    //   //        |event1| |      |
-    //   // 11:00  |      | +------+
-    //   //        |      |
-    //   // 11:30  +------+
-    //   [
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event1',
-    //         start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T11:30:00+0900') },
-    //       })
-    //     ),
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event2',
-    //         start: { dateTime: new Date('2023-07-01T10:00:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T11:00:00+0900') },
-    //       })
-    //     ),
-    //   ],
-    //   (result): void => {
-    //     expect(result.length).toBe(2);
-    //     {
-    //       const actual = result[0];
-    //       expect(actual.overlappingIndex).toBe(0);
-    //       expect(actual.overlappingCount).toBe(2);
-    //     }
-    //     {
-    //       const actual = result[1];
-    //       expect(actual.overlappingIndex).toBe(1);
-    //       expect(actual.overlappingCount).toBe(2);
-    //     }
-    //   },
-    // ],
-    // [
-    //   '部分的に重なるイベント(3)',
-    //   // 10:00  +------+
-    //   //        |event1|
-    //   // 10:30  |      | +------+
-    //   //        |      | |event2|
-    //   // 11:00  |      | |      |
-    //   //        |      | +------+
-    //   // 11:30  +------+
-    //   [
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event1',
-    //         start: { dateTime: new Date('2023-07-01T10:00:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T11:30:00+0900') },
-    //       })
-    //     ),
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event2',
-    //         start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T11:15:00+0900') },
-    //       })
-    //     ),
-    //   ],
-    //   (result): void => {
-    //     expect(result.length).toBe(2);
-    //     {
-    //       const actual = result[0];
-    //       expect(actual.overlappingIndex).toBe(0);
-    //       expect(actual.overlappingCount).toBe(2);
-    //     }
-    //     {
-    //       const actual = result[1];
-    //       expect(actual.overlappingIndex).toBe(1);
-    //       expect(actual.overlappingCount).toBe(2);
-    //     }
-    //   },
-    // ],
-    // [
-    //   '部分的に重なるイベント(4)',
-    //   // 10:00           +------+
-    //   //                 |event2|
-    //   // 10:30  +------+ |      |
-    //   //        |event1| |      |
-    //   // 11:00  |      | |      |
-    //   //        +------+ |      |
-    //   // 11:30           +------+
-    //   [
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event1',
-    //         start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T11:15:00+0900') },
-    //       })
-    //     ),
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event2',
-    //         start: { dateTime: new Date('2023-07-01T10:00:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T11:30:00+0900') },
-    //       })
-    //     ),
-    //   ],
-    //   (result): void => {
-    //     expect(result.length).toBe(2);
-    //     {
-    //       const actual = result[0];
-    //       expect(actual.overlappingIndex).toBe(0);
-    //       expect(actual.overlappingCount).toBe(2);
-    //     }
-    //     {
-    //       const actual = result[1];
-    //       expect(actual.overlappingIndex).toBe(1);
-    //       expect(actual.overlappingCount).toBe(2);
-    //     }
-    //   },
-    // ],
-    // [
-    //   '完全に重なるイベント',
-    //   // 10:00
-    //   //
-    //   // 10:30  +------+ +------+
-    //   //        |event1| |event2|
-    //   // 11:00  |      | |      |
-    //   //        +------+ +------+
-    //   // 11:30
-    //   [
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event1',
-    //         start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T11:15:00+0900') },
-    //       })
-    //     ),
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event2',
-    //         start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T11:15:00+0900') },
-    //       })
-    //     ),
-    //   ],
-    //   (result): void => {
-    //     expect(result.length).toBe(2);
-    //     {
-    //       const actual = result[0];
-    //       expect(actual.overlappingIndex).toBe(0);
-    //       expect(actual.overlappingCount).toBe(2);
-    //     }
-    //     {
-    //       const actual = result[1];
-    //       expect(actual.overlappingIndex).toBe(1);
-    //       expect(actual.overlappingCount).toBe(2);
-    //     }
-    //   },
-    // ],
-    // [
-    //   '重ならないイベント(1)',
-    //   // 10:00  +------+
-    //   //        |event1|
-    //   // 10:30  +------+ +------+
-    //   //                 |event2|
-    //   // 11:00           +------+
-    //   //
-    //   // 11:30
-    //   [
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event1',
-    //         start: { dateTime: new Date('2023-07-01T10:00:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T10:30:00+0900') },
-    //       })
-    //     ),
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event2',
-    //         start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T11:00:00+0900') },
-    //       })
-    //     ),
-    //   ],
-    //   (result): void => {
-    //     expect(result.length).toBe(2);
-    //     {
-    //       const actual = result[0];
-    //       expect(actual.overlappingIndex).toBe(0);
-    //       expect(actual.overlappingCount).toBe(1);
-    //     }
-    //     {
-    //       const actual = result[1];
-    //       expect(actual.overlappingIndex).toBe(0);
-    //       expect(actual.overlappingCount).toBe(1);
-    //     }
-    //   },
-    // ],
-    // [
-    //   '重ならないイベント(2)',
-    //   // 10:00           +------+
-    //   //                 |event2|
-    //   // 10:30  +------+ +------+
-    //   //        |event1|
-    //   // 11:00  +------+
-    //   //
-    //   // 11:30
-    //   [
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event1',
-    //         start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T11:00:00+0900') },
-    //       })
-    //     ),
-    //     eventTimeCellFixture(
-    //       EventEntryFixture.default({
-    //         id: 'event2',
-    //         start: { dateTime: new Date('2023-07-01T10:00:00+0900') },
-    //         end: { dateTime: new Date('2023-07-01T10:30:00+0900') },
-    //       })
-    //     ),
-    //   ],
-    //   (result): void => {
-    //     expect(result.length).toBe(2);
-    //     {
-    //       const actual = result[0];
-    //       expect(actual.overlappingIndex).toBe(0);
-    //       expect(actual.overlappingCount).toBe(1);
-    //     }
-    //     {
-    //       const actual = result[1];
-    //       expect(actual.overlappingIndex).toBe(0);
-    //       expect(actual.overlappingCount).toBe(1);
-    //     }
-    //   },
-    // ],
+    [
+      'empty なイベント',
+      [],
+      (result): void => {
+        expect(result).toEqual([]);
+      },
+    ],
+    [
+      '1つのイベント',
+      [eventTimeCellFixture(EventEntryFixture.default())],
+      (result): void => {
+        expect(result[0].overlappingIndex).toBe(0);
+        expect(result[0].overlappingCount).toBe(1);
+      },
+    ],
+    [
+      '部分的に重なるイベント(1)',
+      // 10:00  +------+
+      //        |event1|
+      // 10:30  |      | +------+
+      //        |      | |event2|
+      // 11:00  +------+ |      |
+      //                 |      |
+      // 11:30           +------+
+      [
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event1',
+            start: { dateTime: new Date('2023-07-01T10:00:00+0900') },
+            end: { dateTime: new Date('2023-07-01T11:00:00+0900') },
+          })
+        ),
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event2',
+            start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
+            end: { dateTime: new Date('2023-07-01T11:30:00+0900') },
+          })
+        ),
+      ],
+      (result): void => {
+        expect(result.length).toBe(2);
+        {
+          const actual = result[0];
+          expect(actual.overlappingIndex).toBe(0);
+          expect(actual.overlappingCount).toBe(2);
+        }
+        {
+          const actual = result[1];
+          expect(actual.overlappingIndex).toBe(1);
+          expect(actual.overlappingCount).toBe(2);
+        }
+      },
+    ],
+    [
+      '部分的に重なるイベント(2)',
+      // 10:00           +------+
+      //                 |event2|
+      // 10:30  +------+ |      |
+      //        |event1| |      |
+      // 11:00  |      | +------+
+      //        |      |
+      // 11:30  +------+
+      [
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event1',
+            start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
+            end: { dateTime: new Date('2023-07-01T11:30:00+0900') },
+          })
+        ),
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event2',
+            start: { dateTime: new Date('2023-07-01T10:00:00+0900') },
+            end: { dateTime: new Date('2023-07-01T11:00:00+0900') },
+          })
+        ),
+      ],
+      (result): void => {
+        expect(result.length).toBe(2);
+        {
+          const actual = result[0];
+          expect(actual.overlappingIndex).toBe(0);
+          expect(actual.overlappingCount).toBe(2);
+          expect(actual.id).toBe('event2');
+        }
+        {
+          const actual = result[1];
+          expect(actual.overlappingIndex).toBe(1);
+          expect(actual.overlappingCount).toBe(2);
+          expect(actual.id).toBe('event1');
+        }
+      },
+    ],
+    [
+      '部分的に重なるイベント(3)',
+      // 10:00  +------+
+      //        |event1|
+      // 10:30  |      | +------+
+      //        |      | |event2|
+      // 11:00  |      | |      |
+      //        |      | +------+
+      // 11:30  +------+
+      [
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event1',
+            start: { dateTime: new Date('2023-07-01T10:00:00+0900') },
+            end: { dateTime: new Date('2023-07-01T11:30:00+0900') },
+          })
+        ),
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event2',
+            start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
+            end: { dateTime: new Date('2023-07-01T11:15:00+0900') },
+          })
+        ),
+      ],
+      (result): void => {
+        expect(result.length).toBe(2);
+        {
+          const actual = result[0];
+          expect(actual.overlappingIndex).toBe(0);
+          expect(actual.overlappingCount).toBe(2);
+        }
+        {
+          const actual = result[1];
+          expect(actual.overlappingIndex).toBe(1);
+          expect(actual.overlappingCount).toBe(2);
+        }
+      },
+    ],
+    [
+      '部分的に重なるイベント(4)',
+      // 10:00           +------+
+      //                 |event2|
+      // 10:30  +------+ |      |
+      //        |event1| |      |
+      // 11:00  |      | |      |
+      //        +------+ |      |
+      // 11:30           +------+
+      [
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event1',
+            start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
+            end: { dateTime: new Date('2023-07-01T11:15:00+0900') },
+          })
+        ),
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event2',
+            start: { dateTime: new Date('2023-07-01T10:00:00+0900') },
+            end: { dateTime: new Date('2023-07-01T11:30:00+0900') },
+          })
+        ),
+      ],
+      (result): void => {
+        expect(result.length).toBe(2);
+        {
+          const actual = result[0];
+          expect(actual.overlappingIndex).toBe(0);
+          expect(actual.overlappingCount).toBe(2);
+        }
+        {
+          const actual = result[1];
+          expect(actual.overlappingIndex).toBe(1);
+          expect(actual.overlappingCount).toBe(2);
+        }
+      },
+    ],
+    [
+      '完全に重なるイベント',
+      // 10:00
+      //
+      // 10:30  +------+ +------+
+      //        |event1| |event2|
+      // 11:00  |      | |      |
+      //        +------+ +------+
+      // 11:30
+      [
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event1',
+            start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
+            end: { dateTime: new Date('2023-07-01T11:15:00+0900') },
+          })
+        ),
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event2',
+            start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
+            end: { dateTime: new Date('2023-07-01T11:15:00+0900') },
+          })
+        ),
+      ],
+      (result): void => {
+        expect(result.length).toBe(2);
+        {
+          const actual = result[0];
+          expect(actual.overlappingIndex).toBe(0);
+          expect(actual.overlappingCount).toBe(2);
+        }
+        {
+          const actual = result[1];
+          expect(actual.overlappingIndex).toBe(1);
+          expect(actual.overlappingCount).toBe(2);
+        }
+      },
+    ],
+    [
+      '重ならないイベント(1)',
+      // 10:00  +------+
+      //        |event1|
+      // 10:30  +------+ +------+
+      //                 |event2|
+      // 11:00           +------+
+      //
+      // 11:30
+      [
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event1',
+            start: { dateTime: new Date('2023-07-01T10:00:00+0900') },
+            end: { dateTime: new Date('2023-07-01T10:30:00+0900') },
+          })
+        ),
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event2',
+            start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
+            end: { dateTime: new Date('2023-07-01T11:00:00+0900') },
+          })
+        ),
+      ],
+      (result): void => {
+        expect(result.length).toBe(2);
+        {
+          const actual = result[0];
+          expect(actual.overlappingIndex).toBe(0);
+          expect(actual.overlappingCount).toBe(1);
+        }
+        {
+          const actual = result[1];
+          expect(actual.overlappingIndex).toBe(0);
+          expect(actual.overlappingCount).toBe(1);
+        }
+      },
+    ],
+    [
+      '重ならないイベント(2)',
+      // 10:00           +------+
+      //                 |event2|
+      // 10:30  +------+ +------+
+      //        |event1|
+      // 11:00  +------+
+      //
+      // 11:30
+      [
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event1',
+            start: { dateTime: new Date('2023-07-01T10:30:00+0900') },
+            end: { dateTime: new Date('2023-07-01T11:00:00+0900') },
+          })
+        ),
+        eventTimeCellFixture(
+          EventEntryFixture.default({
+            id: 'event2',
+            start: { dateTime: new Date('2023-07-01T10:00:00+0900') },
+            end: { dateTime: new Date('2023-07-01T10:30:00+0900') },
+          })
+        ),
+      ],
+      (result): void => {
+        expect(result.length).toBe(2);
+        {
+          const actual = result[0];
+          expect(actual.overlappingIndex).toBe(0);
+          expect(actual.overlappingCount).toBe(1);
+        }
+        {
+          const actual = result[1];
+          expect(actual.overlappingIndex).toBe(0);
+          expect(actual.overlappingCount).toBe(1);
+        }
+      },
+    ],
     [
       '3つの重なりイベント(1)',
       // 10:00  +------+

--- a/src/shared/utils/StrUtil.ts
+++ b/src/shared/utils/StrUtil.ts
@@ -1,0 +1,10 @@
+/**
+ * 文字列がnull、undefined、空、または空白のみで構成されているかどうかを判断します。
+ * この実装はcommons-langのisBlankに近い動作をするように意図されています。
+ *
+ * @param {string | null | undefined} str - 検査する文字列
+ * @return {boolean} 文字列が空白であればtrue, そうでなければfalse
+ */
+export const isBlank = (str: string | null | undefined): boolean => {
+  return !str || /^\s*$/.test(str);
+};


### PR DESCRIPTION
Issue: #95 

Issueのエントリー内容は「登録していない実績が登録されている」ということなのだが、
D&Dの不具合が修正されたことで、その現象は、再現しなくなってしまったが、
サービス層にバリデーションが実装されていなかった不具合だけ対応した。

また、Google風のカレンダー表示を数段階で実装追加しているのだが、その段階で、
縦横の座標計算がバラバラのえuseEffectで実装されていて、うまく連動していなかったので、
1つの useEffect に実装して、座標計算の処理を1つにまとめて、重なり具合の不具合も修正した。
