### PR TITLE
refactor: #102 CRUDの一覧表示からIDの列を削除

### DIFF
--- a/src/renderer/src/components/category/CategoryList.tsx
+++ b/src/renderer/src/components/category/CategoryList.tsx
@@ -24,11 +24,6 @@ const buildColumnData = (overlaps: Partial<CRUDColumnData<Category>>): CRUDColum
 
 const headCells: readonly CRUDColumnData<Category>[] = [
   buildColumnData({
-    isKey: true,
-    id: 'id',
-    label: 'カテゴリーID',
-  }),
-  buildColumnData({
     id: 'name',
     label: 'カテゴリー名',
   }),
@@ -45,7 +40,7 @@ const headCells: readonly CRUDColumnData<Category>[] = [
   }),
 ];
 
-const DEFAULT_ORDER = 'id';
+const DEFAULT_ORDER = 'name';
 const DEFAULT_SORT_DIRECTION = 'asc';
 const DEFAULT_PAGE_SIZE = 10;
 

--- a/src/renderer/src/components/label/LabelList.tsx
+++ b/src/renderer/src/components/label/LabelList.tsx
@@ -24,11 +24,6 @@ const buildColumnData = (overlaps: Partial<CRUDColumnData<Label>>): CRUDColumnDa
 
 const headCells: readonly CRUDColumnData<Label>[] = [
   buildColumnData({
-    isKey: true,
-    id: 'id',
-    label: 'ラベルID',
-  }),
-  buildColumnData({
     id: 'name',
     label: 'ラベル名',
   }),
@@ -45,7 +40,7 @@ const headCells: readonly CRUDColumnData<Label>[] = [
   }),
 ];
 
-const DEFAULT_ORDER = 'id';
+const DEFAULT_ORDER = 'name';
 const DEFAULT_SORT_DIRECTION = 'asc';
 const DEFAULT_PAGE_SIZE = 10;
 

--- a/src/renderer/src/components/project/ProjectList.tsx
+++ b/src/renderer/src/components/project/ProjectList.tsx
@@ -23,11 +23,6 @@ const buildColumnData = (overlaps: Partial<CRUDColumnData<Project>>): CRUDColumn
 
 const headCells: readonly CRUDColumnData<Project>[] = [
   buildColumnData({
-    isKey: true,
-    id: 'id',
-    label: 'プロジェクトID',
-  }),
-  buildColumnData({
     id: 'name',
     label: 'プロジェクト名',
   }),
@@ -37,7 +32,7 @@ const headCells: readonly CRUDColumnData<Project>[] = [
   }),
 ];
 
-const DEFAULT_ORDER = 'id';
+const DEFAULT_ORDER = 'name';
 const DEFAULT_SORT_DIRECTION = 'asc';
 const DEFAULT_PAGE_SIZE = 10;
 

--- a/src/renderer/src/pages/SettingPage.tsx
+++ b/src/renderer/src/pages/SettingPage.tsx
@@ -22,7 +22,7 @@ export const SettingPage = (): JSX.Element => {
           <Tab label="一般" {...a11yProps(0)} />
           <Tab label="Googleカレンダー" {...a11yProps(1)} />
           <Tab label="プロジェクト" {...a11yProps(2)} />
-          <Tab label="作業区分" {...a11yProps(3)} />
+          <Tab label="カテゴリー" {...a11yProps(3)} />
           <Tab label="ラベル" {...a11yProps(4)} />
           <Tab label="アカウント" {...a11yProps(5)} />
         </Tabs>


### PR DESCRIPTION
Issue: #102 

- UUIDで採番されているIDを一覧で見ても、役に立たないし、id と name がそれぞれユニーク制約にしてあるので、idの表示列は不要
- 設定画面の「作業区分」をカテゴリーに変更（他のところではカテゴリーと表示しているので）