### PR TITLE
feat: #114 背景色とテキストカラーの配色を最適化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-router-dom": "^6.14.0",
         "reflect-metadata": "^0.1.13",
         "styled-components": "^5.3.11",
+        "tinycolor2": "^1.6.0",
         "utf-8-validate": "^6.0.3",
         "uuid": "^9.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-router-dom": "^6.14.0",
     "reflect-metadata": "^0.1.13",
     "styled-components": "^5.3.11",
+    "tinycolor2": "^1.6.0",
     "utf-8-validate": "^6.0.3",
     "uuid": "^9.0.0"
   },

--- a/src/renderer/src/components/timeTable/ActivitySlot.tsx
+++ b/src/renderer/src/components/timeTable/ActivitySlot.tsx
@@ -19,6 +19,7 @@ import {
 } from '@renderer/services/EventTimeCell';
 import { useContext, useEffect, useState } from 'react';
 import { CheckCircle } from '@mui/icons-material';
+import { getOptimalTextColor } from '@renderer/utils/ColotUtil';
 
 interface SlotRect {
   x: number;
@@ -82,7 +83,7 @@ export const ActivitySlot = ({ eventTimeCell, children }: ActivitySlotProps): JS
       eventTimeCell: EventTimeCell,
       prevRect: SlotRect
     ): void => {
-      const width = parentWidth / eventTimeCell.overlappingCount;
+      const width = (parentWidth - 2) / eventTimeCell.overlappingCount;
       const x = width * eventTimeCell.overlappingIndex;
       const y = convertDateToTableOffset(eventTimeCell.cellFrameStart) * cellHeightPx;
       const newDurationHours =
@@ -117,8 +118,10 @@ export const ActivitySlot = ({ eventTimeCell, children }: ActivitySlotProps): JS
     return () => {};
   }, [parentRef, eventTimeCell, slotRect, cellHeightPx]);
 
-  const color = theme.palette.primary.contrastText;
   const backgroundColor = eventTimeCell.backgroundColor;
+  const color = backgroundColor
+    ? getOptimalTextColor(backgroundColor)
+    : theme.palette.primary.contrastText;
 
   let desc: React.ReactElement;
   // TODO eventTimeCell を汎化しているのに、ここで instanceof で分岐するのは、あまりよくない

--- a/src/renderer/src/components/timeTable/ActivitySlot.tsx
+++ b/src/renderer/src/components/timeTable/ActivitySlot.tsx
@@ -122,6 +122,7 @@ export const ActivitySlot = ({ eventTimeCell, children }: ActivitySlotProps): JS
   const color = backgroundColor
     ? getOptimalTextColor(backgroundColor)
     : theme.palette.primary.contrastText;
+  const borderColor = theme.palette.mode === 'dark' ? 'black' : 'white';
 
   let desc: React.ReactElement;
   // TODO eventTimeCell を汎化しているのに、ここで instanceof で分岐するのは、あまりよくない
@@ -180,7 +181,8 @@ export const ActivitySlot = ({ eventTimeCell, children }: ActivitySlotProps): JS
         sx={{
           width: slotRect.width,
           borderRadius: 0.5,
-          border: '1px solid #fff',
+          border: '1px solid',
+          borderColor: borderColor,
           height: slotRect.height,
           fontSize: '12px',
           backgroundColor: backgroundColor,

--- a/src/renderer/src/components/timeTable/EventSlot.tsx
+++ b/src/renderer/src/components/timeTable/EventSlot.tsx
@@ -4,6 +4,7 @@ import { Rnd } from 'react-rnd';
 import { useContext, useEffect, useState } from 'react';
 import { addMinutes, differenceInMinutes } from 'date-fns';
 import { EventEntryTimeCell } from '@renderer/services/EventTimeCell';
+import { getOptimalTextColor } from '@renderer/utils/ColotUtil';
 
 export interface DragDropResizeState {
   eventTimeCell: EventEntryTimeCell;
@@ -66,6 +67,7 @@ export const EventSlot = ({
   color,
   backgroundColor,
 }: EventSlotProps): JSX.Element => {
+  console.log('EventSlot called with:', eventTimeCell.summary);
   const parentRef = useContext(ParentRefContext);
   const theme = useTheme();
   // 1時間の枠の高さ
@@ -229,6 +231,9 @@ export const EventSlot = ({
     setDragDropResizeState(newState);
   };
 
+  const textColor = getOptimalTextColor(theme.palette.primary.main);
+  const borderColor = theme.palette.mode === 'dark' ? 'black' : 'white';
+
   return (
     <Rnd
       bounds={bounds}
@@ -236,9 +241,10 @@ export const EventSlot = ({
         display: 'flex',
         width: 'calc(100% - 1px)',
         height: dragDropResizeState.height,
-        border: '1px solid #fff',
+        border: '1px solid',
+        borderColor: borderColor,
         borderRadius: 0.5,
-        color: color,
+        color: textColor,
         background: backgroundColor,
         paddingLeft: '0.25rem',
         fontSize: '12px',

--- a/src/renderer/src/components/timeTable/EventSlot.tsx
+++ b/src/renderer/src/components/timeTable/EventSlot.tsx
@@ -20,7 +20,6 @@ interface EventSlotProps {
   onClick?: () => void;
   onDragStop: (state: DragDropResizeState) => void;
   onResizeStop: (state: DragDropResizeState) => void;
-  color?: string;
   backgroundColor?: string;
   children?: React.ReactNode;
 }
@@ -64,7 +63,6 @@ export const EventSlot = ({
   onDragStop,
   onResizeStop,
   children,
-  color,
   backgroundColor,
 }: EventSlotProps): JSX.Element => {
   console.log('EventSlot called with:', eventTimeCell.summary);

--- a/src/renderer/src/components/timeTable/EventSlotText.tsx
+++ b/src/renderer/src/components/timeTable/EventSlotText.tsx
@@ -3,6 +3,7 @@ import { EventEntryTimeCell } from '@renderer/services/EventTimeCell';
 import { useLabelMap } from '@renderer/hooks/useLabelMap';
 import { useProjectMap } from '@renderer/hooks/useProjectMap';
 import { useCategoryMap } from '@renderer/hooks/useCategoryMap';
+import { getOptimalTextColor } from '@renderer/utils/ColotUtil';
 
 interface EventSlotTextProps {
   eventTimeCell: EventEntryTimeCell;
@@ -35,11 +36,17 @@ export const EventSlotText = ({ eventTimeCell }: EventSlotTextProps): JSX.Elemen
   if (!isCategoryLoading && eventTimeCell.event.categoryId) {
     const category = categoryMap.get(eventTimeCell.event.categoryId);
     if (category) {
+      const textColor = getOptimalTextColor(category.color);
       chips.push(
         <Chip
           key={`category-${category.id}`}
           label={category.name}
-          style={{ backgroundColor: category.color, marginRight: '2px', padding: '1px' }}
+          style={{
+            backgroundColor: category.color,
+            marginRight: '2px',
+            padding: '1px',
+            color: textColor,
+          }}
           size="small"
           variant="outlined"
         />
@@ -53,11 +60,12 @@ export const EventSlotText = ({ eventTimeCell }: EventSlotTextProps): JSX.Elemen
       if (!label) {
         continue;
       }
+      const textColor = getOptimalTextColor(label.color);
       chips.push(
         <Chip
           key={`label-${label.id}`}
           label={label.name}
-          style={{ backgroundColor: label.color, marginRight: '2px' }}
+          style={{ backgroundColor: label.color, marginRight: '2px', color: textColor }}
           size="small"
         />
       );

--- a/src/renderer/src/components/timeTable/TimeLane.tsx
+++ b/src/renderer/src/components/timeTable/TimeLane.tsx
@@ -9,7 +9,6 @@ import { EventSlotText } from './EventSlotText';
 
 interface TimeLaneProps {
   name: string;
-  color: string;
   backgroundColor: string;
   overlappedEvents: EventEntryTimeCell[];
   onAddEventEntry: (hour: number) => void;
@@ -24,7 +23,6 @@ interface TimeLaneProps {
  */
 export const TimeLane = ({
   name,
-  color,
   backgroundColor,
   overlappedEvents,
   onAddEventEntry,
@@ -39,7 +37,6 @@ export const TimeLane = ({
           key={oe.id}
           bounds={`.${name}`}
           eventTimeCell={oe}
-          color={color}
           backgroundColor={backgroundColor}
           onClick={(): void => onUpdateEventEntry(oe.event)}
           onDragStop={onDragStop}

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -270,7 +270,6 @@ const TimeTable = (): JSX.Element => {
           {overlappedPlanEvents && (
             <TimeLane
               name="plan"
-              color={theme.palette.primary.contrastText}
               backgroundColor={theme.palette.primary.main}
               overlappedEvents={overlappedPlanEvents}
               onAddEventEntry={(hour: number): void => {
@@ -291,7 +290,6 @@ const TimeTable = (): JSX.Element => {
           {overlappedActualEvents && (
             <TimeLane
               name="actual"
-              color={theme.palette.secondary.contrastText}
               backgroundColor={theme.palette.secondary.main}
               overlappedEvents={overlappedActualEvents}
               onAddEventEntry={(hour: number): void => {

--- a/src/renderer/src/services/EventTimeCell.ts
+++ b/src/renderer/src/services/EventTimeCell.ts
@@ -6,6 +6,13 @@ import { addMinutes, differenceInMinutes } from 'date-fns';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import React from 'react';
 
+// イベント枠の最小高さ＝30分
+const MIN_EVENT_CELL_HEIGHT = 30;
+
+// GitHubイベントの最小高さ＝30分
+// GitHubアイコンの高さが30分くらいの高さがないと欠けるので
+const GITHUB_EVENT_CELL_HEIGHT = 30;
+
 export abstract class EventTimeCell {
   private _overlappingIndex = 0;
   private _overlappingCount = 0;
@@ -50,8 +57,8 @@ export abstract class EventTimeCell {
 
   get cellFrameEnd(): Date {
     let mins = differenceInMinutes(this.endTime, this.startTime);
-    if (mins < 15) {
-      mins = 15;
+    if (mins < MIN_EVENT_CELL_HEIGHT) {
+      mins = MIN_EVENT_CELL_HEIGHT;
       const endTime = addMinutes(this.startTime, mins);
       return endTime;
     }
@@ -276,11 +283,10 @@ export class GitHubEventTimeCell extends EventTimeCell {
       const p = event.payload;
       description = JSON.stringify(p);
     }
-    // GitHubアイコンの高さが30分くらいの高さがないと欠けるので、
-    // GitHubイベントは30分で表示する
+
     const eventTimeCell = new GitHubEventTimeCell(
       event.updated_at,
-      addMinutes(event.updated_at, 30),
+      addMinutes(event.updated_at, GITHUB_EVENT_CELL_HEIGHT),
       event
     );
     eventTimeCell._summary = summary;

--- a/src/renderer/src/utils/ColotUtil.ts
+++ b/src/renderer/src/utils/ColotUtil.ts
@@ -1,0 +1,16 @@
+import tinycolor from 'tinycolor2';
+
+/**
+ * 背景色から最適なテキストの色（白 or 黒）を決定する
+ * @param backgroundColor - 背景色
+ * @returns "black" または "white"
+ */
+export const getOptimalTextColor = (backgroundColor: string): string => {
+  const color = tinycolor(backgroundColor);
+  const rgb = color.toRgb();
+
+  // 輝度を計算（sRGB空間での計算）
+  const luminance = (0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b) / 255;
+
+  return luminance >= 0.5 ? '#000000' : '#FFFFFF';
+};


### PR DESCRIPTION
Issue: #114 

- 背景色の輝度からテキストカラーを選択
- イベントの枠線をテーマ色に合わせて切替
- イベントの最小枠高さを30分に変更