### PR TITLE
feat: #122 アクティビティのタイムラインにGitHubイベントも表示

### DIFF
--- a/src/renderer/src/components/timeTable/ActivityTimeline.tsx
+++ b/src/renderer/src/components/timeTable/ActivityTimeline.tsx
@@ -120,6 +120,17 @@ export const ActivityTimeline = ({
     );
   }
 
+  if (events.length === 0) {
+    return (
+      <>
+        <Card variant="outlined">
+          <CardHeader title="アクティビティ" />
+          <CardContent>アクティビティはありません</CardContent>
+        </Card>
+      </>
+    );
+  }
+
   return (
     <>
       <Card variant="outlined">

--- a/src/renderer/src/components/timeTable/ActivityTimeline.tsx
+++ b/src/renderer/src/components/timeTable/ActivityTimeline.tsx
@@ -10,116 +10,172 @@ import TimelineOppositeContent, {
 import { useActivityEvents } from '@renderer/hooks/useActivityEvents';
 import { ActivityEvent } from '@shared/data/ActivityEvent';
 import { differenceInSeconds, format, formatDuration } from 'date-fns';
-import { useEffect, useState } from 'react';
-import { Card, CardContent, Chip, Typography } from '@mui/material';
+import { ForwardedRef, forwardRef, useEffect, useRef, useState } from 'react';
+import { Card, CardContent, CardHeader, Chip, Typography } from '@mui/material';
+import { GitHubEvent } from '@shared/data/GitHubEvent';
+import { GitHubEventTimeCell } from '@renderer/services/EventTimeCell';
+import GitHubIcon from '@mui/icons-material/GitHub';
 
-interface ActivityTimelineProps {
-  selectedDate: Date;
-  startTime: Date;
-  endTime: Date;
+type ActivityOrGitHub = 'activity' | 'github';
+
+/**
+ * ActivityOrGitHubEvent は、アクティビティとGitHubイベントを時間でソートするために、
+ * 同じ配列にまとめるための Union 用の interface である。
+ */
+interface ActivityOrGitHubEvent {
+  id: string;
+  type: ActivityOrGitHub;
+  time: Date;
+  activity: ActivityEvent;
+  github: GitHubEvent;
 }
 
+interface ActivityTimelineProps {
+  /** タイムラインを表示する日付 */
+  selectedDate: Date;
+  /** タイムラインのフォーカス表示開始時間 */
+  focusTimeStart: Date;
+  /** タイムラインのフォーカス表示終了時間 */
+  focusTimeEnd: Date;
+}
+
+/**
+ * アクティビティとGitHubイベントを一覧で表示するタイムラインコンポーネント。
+ * 作業実績を記録するときに参照することを想定していて、実績を記録しようとしている時間帯に、
+ * どんな作業を行っていたのかを思い出しやすくするための視覚的なサポートを目的としたコンポーネントである。
+ *
+ * タイムラインは、1日分のすべてのイベントを表示するが、作業実績を記録ときに、
+ * 対象としている時間帯にフォーカスしやすいように、フォーカス表示時間を指定することができて、
+ * 初期表示時および focusTimeStart が変更されたときに、その時間位置にスクロールする。
+ * また、フォーカス表示時間から外れているイベントは、透明度を下げて表示することで、
+ * 対象としている時間帯の境界がわかるようにする。
+ */
 export const ActivityTimeline = ({
   selectedDate,
-  startTime: defaultStartTime,
-  endTime: defaultEndTime,
+  focusTimeStart: defaultStartTime,
+  focusTimeEnd: defaultEndTime,
 }: ActivityTimelineProps): JSX.Element => {
   console.log('ActivityTimeline', defaultStartTime, defaultEndTime);
-  const { activityEvents } = useActivityEvents(selectedDate);
-  const [events, setEvents] = useState<ActivityEvent[]>([]);
-  const [startTime, setStartTime] = useState<number>(defaultStartTime.getTime());
-  const [endTime, setEndTime] = useState<number>(defaultEndTime.getTime());
+  const { activityEvents, githubEvents } = useActivityEvents(selectedDate);
+
+  const [events, setEvents] = useState<ActivityOrGitHubEvent[]>([]);
+  const [focusTimeStart, setFocusTimeStart] = useState<number>(defaultStartTime.getTime());
+  const [focusTimeEnd, setFocusTimeEnd] = useState<number>(defaultEndTime.getTime());
 
   useEffect(() => {
-    setStartTime(defaultStartTime.getTime());
-    setEndTime(defaultEndTime.getTime());
+    setFocusTimeStart(defaultStartTime.getTime());
+    setFocusTimeEnd(defaultEndTime.getTime());
   }, [defaultStartTime, defaultEndTime]);
 
   useEffect(() => {
-    console.log('useEffect', startTime, endTime, activityEvents);
-    if (activityEvents) {
-      const newEvents = activityEvents.filter((e) => {
-        return e.end.getTime() >= startTime && e.start.getTime() <= endTime;
-      });
-      console.log('newEvents', newEvents);
-      setEvents(newEvents);
+    if (!activityEvents || !githubEvents) {
+      return;
     }
-  }, [activityEvents, startTime, endTime]);
+    const activities = activityEvents.map(
+      (e) => ({ id: e.id, type: 'activity', time: e.start, activity: e } as ActivityOrGitHubEvent)
+    );
+    const githubs = githubEvents.map(
+      (e) => ({ id: e.id, type: 'github', time: e.updated_at, github: e } as ActivityOrGitHubEvent)
+    );
+    const merged = activities.concat(githubs).sort((a, b) => {
+      return a.time.getTime() - b.time.getTime();
+    });
+    setEvents(merged);
+  }, [activityEvents, githubEvents]);
 
-  let lastEvent: ActivityEvent | null = null;
+  // 初期表示時に focusTimeStart に最も近い event の位置 にスクロールする
+  // スクロール用のref
+  const closestEventRef = useRef<HTMLElement | null>(null);
+  // 最近似の event を求める
+  const closestEvent = events.reduce((closest, current) => {
+    const currentDiff = Math.abs(current.time.getTime() - focusTimeStart);
+    const closestDiff = Math.abs(closest.time.getTime() - focusTimeStart);
+
+    return currentDiff < closestDiff ? current : closest;
+  }, events[0]);
+  // スクロールする
+  useEffect(() => {
+    console.log('scrollIntoView', closestEventRef.current);
+    if (closestEventRef.current) {
+      closestEventRef.current.scrollIntoView({
+        behavior: 'smooth',
+      });
+    }
+  }, [events, closestEventRef, focusTimeStart]);
+
+  // lastEvent は、タイムラインの最後のアイテムとして終了時間を表示するためのものである。
+  // events の配列を表示するところでは、イベントの開始時間と明細としての duration しか表示されないくて、
+  // 一番最後のイベントが何時に終わったのかがわかりづらいため、終了時間だけを表示する。
+  let lastEvent: ActivityOrGitHubEvent | null = null;
+  let lastEventColor = 'default';
+  let lastTime = '';
   if (events.length > 0) {
     lastEvent = events[events.length - 1];
+    if (lastEvent.type === 'activity' && lastEvent.activity.appColor) {
+      lastEventColor = lastEvent.activity.appColor;
+    }
+    lastTime = format(
+      lastEvent.type === 'activity' ? lastEvent.activity.end : lastEvent.github.updated_at,
+      'HH:mm'
+    );
   }
 
   return (
     <>
-      <Card>
-        <CardContent>
-          <Typography variant="h6" component="div">
-            アクティビティ
-          </Typography>
+      <Card variant="outlined">
+        <CardHeader title="アクティビティ" />
+        <CardContent
+          sx={{
+            [`& .${timelineOppositeContentClasses.root}`]: {
+              flex: 0.2,
+            },
+            paddingTop: 0,
+            marginTop: '0rem',
+            maxHeight: 'calc(28rem + 4px)',
+            overflowY: 'scroll',
+            overflowX: 'hidden',
+          }}
+        >
           <Timeline
             sx={{
               [`& .${timelineOppositeContentClasses.root}`]: {
                 flex: 0.2,
               },
               padding: 0,
+              marginTop: '0rem',
               marginLeft: '-1rem',
               marginRight: '-1rem',
             }}
           >
-            {events.map((event) => (
-              <TimelineItem key={event.id}>
-                <TimelineOppositeContent color="textSecondary">
-                  {format(event.start, 'HH:mm')}
-                </TimelineOppositeContent>
-                <TimelineSeparator>
-                  <TimelineDot style={{ backgroundColor: event.appColor || 'default' }} />
-                  <TimelineConnector />
-                </TimelineSeparator>
-                <TimelineContent>
-                  <Typography variant="subtitle1">{event.basename}</Typography>
-                  {event.details.map((d, index) => {
-                    const secs = differenceInSeconds(d.end, d.start);
-                    const mins = Math.floor(secs / 60);
-                    const hours = Math.floor(mins / 60);
-                    const duration = {
-                      hours: hours,
-                      minutes: mins % 60,
-                      seconds: secs % 60,
-                    };
-                    const formatOptions = { format: ['hours', 'minutes', 'seconds'] };
-                    const durationStr = formatDuration(duration, formatOptions)
-                      .replace('hours', '時間')
-                      .replace('hour', '時間')
-                      .replace('minutes', '分')
-                      .replace('minute', '分')
-                      .replace('seconds', '秒')
-                      .replace('second', '秒');
-                    return (
-                      <>
-                        <Typography key={`title-${index}`} variant="body2" component="div">
-                          <Chip
-                            label={durationStr}
-                            size="small"
-                            variant="outlined"
-                            sx={{ marginRight: '0.5rem' }}
-                          />
-                          {d.windowTitle}
-                        </Typography>
-                      </>
-                    );
-                  })}
-                </TimelineContent>
-              </TimelineItem>
-            ))}
+            {events.map((event) => {
+              const ref = event.id === closestEvent.id ? closestEventRef : null;
+              if (event.type === 'activity') {
+                return (
+                  <ActivityTimelineItemRef
+                    key={event.id}
+                    event={event.activity}
+                    ref={ref}
+                    focusTimeStart={focusTimeStart}
+                    focusTimeEnd={focusTimeEnd}
+                  />
+                );
+              } else {
+                return (
+                  <GitHubTimelineItemRef
+                    key={event.id}
+                    event={event.github}
+                    ref={ref}
+                    focusTimeStart={focusTimeStart}
+                    focusTimeEnd={focusTimeEnd}
+                  />
+                );
+              }
+            })}
             {lastEvent && (
               <TimelineItem>
-                <TimelineOppositeContent color="textSecondary">
-                  {format(lastEvent.end, 'HH:mm')}
-                </TimelineOppositeContent>
+                <TimelineOppositeContent color="textSecondary">{lastTime}</TimelineOppositeContent>
                 <TimelineSeparator>
-                  <TimelineDot style={{ backgroundColor: lastEvent.appColor || 'default' }} />
+                  <TimelineDot style={{ backgroundColor: lastEventColor }} />
                 </TimelineSeparator>
                 <TimelineContent></TimelineContent>
               </TimelineItem>
@@ -130,3 +186,123 @@ export const ActivityTimeline = ({
     </>
   );
 };
+
+interface ActivityTimelineItemProps {
+  event: ActivityEvent;
+  focusTimeStart: number;
+  focusTimeEnd: number;
+}
+
+/**
+ * アクティビティイベントを表示するタイムラインアイテムコンポーネント。
+ */
+const ActivityTimelineItem = (
+  { event, focusTimeStart, focusTimeEnd }: ActivityTimelineItemProps,
+  ref?: ForwardedRef<HTMLElement>
+): JSX.Element => {
+  const opacity =
+    event.start.getTime() < focusTimeStart || event.end.getTime() > focusTimeEnd ? 0.7 : undefined;
+  return (
+    <>
+      <TimelineItem ref={ref} sx={{ opacity: opacity }}>
+        <TimelineOppositeContent color="textSecondary">
+          {format(event.start, 'HH:mm')}
+        </TimelineOppositeContent>
+        <TimelineSeparator>
+          <TimelineDot style={{ backgroundColor: event.appColor || 'default' }} />
+          <TimelineConnector />
+        </TimelineSeparator>
+        <TimelineContent>
+          <Typography variant="subtitle1" component="div" sx={{ overflow: 'hidden' }}>
+            {event.basename}
+          </Typography>
+          {event.details.map((d, index) => {
+            const secs = differenceInSeconds(d.end, d.start);
+            const mins = Math.floor(secs / 60);
+            const hours = Math.floor(mins / 60);
+            const duration = {
+              hours: hours,
+              minutes: mins % 60,
+              seconds: secs % 60,
+            };
+            const formatOptions = { format: ['hours', 'minutes', 'seconds'] };
+            const durationStr = formatDuration(duration, formatOptions)
+              .replace(/hours?/, '時間')
+              .replace(/minutes?/, '分')
+              .replace(/seconds?/, '秒');
+            return (
+              <>
+                <Typography key={`title-${index}`} variant="body2" component="div">
+                  <Chip
+                    label={durationStr}
+                    size="small"
+                    variant="outlined"
+                    sx={{ marginRight: '0.5rem' }}
+                  />
+                  {d.windowTitle}
+                </Typography>
+              </>
+            );
+          })}
+        </TimelineContent>
+      </TimelineItem>
+    </>
+  );
+};
+const ActivityTimelineItemRef = forwardRef(ActivityTimelineItem);
+ActivityTimelineItemRef.displayName = 'ActivityTimelineItem';
+
+interface GitHubTimelineItemProps {
+  event: GitHubEvent;
+  focusTimeStart: number;
+  focusTimeEnd: number;
+}
+
+/**
+ * GitHubイベントを表示するタイムラインアイテムコンポーネント。
+ */
+const GitHubTimelineItem = (
+  { event, focusTimeStart, focusTimeEnd }: GitHubTimelineItemProps,
+  ref?: ForwardedRef<HTMLElement>
+): JSX.Element => {
+  const ge = GitHubEventTimeCell.fromGitHubEvent(event);
+  const opacity =
+    event.updated_at.getTime() < focusTimeStart || event.updated_at.getTime() > focusTimeEnd
+      ? 0.7
+      : undefined;
+  return (
+    <>
+      <TimelineItem ref={ref} sx={{ opacity: opacity }}>
+        <TimelineOppositeContent color="textSecondary">
+          {format(ge.startTime, 'HH:mm')}
+        </TimelineOppositeContent>
+        <TimelineSeparator>
+          <TimelineDot />
+          <TimelineConnector />
+        </TimelineSeparator>
+        <TimelineContent>
+          <Typography
+            variant="subtitle1"
+            component="div"
+            style={{ display: 'flex', alignItems: 'center' }}
+          >
+            <GitHubIcon sx={{ marginRight: '0.5rem' }} />
+            {ge.summary}
+          </Typography>
+          <Typography
+            variant="body2"
+            component="div"
+            style={{
+              whiteSpace: 'pre-wrap',
+              overflowWrap: 'break-word',
+            }}
+          >
+            {ge.description}
+          </Typography>
+        </TimelineContent>
+      </TimelineItem>
+    </>
+  );
+};
+const GitHubTimelineItemRef = forwardRef(GitHubTimelineItem);
+GitHubTimelineItemRef.displayName = 'GitHubTimelineItem';

--- a/src/renderer/src/components/timeTable/EventEntryForm.tsx
+++ b/src/renderer/src/components/timeTable/EventEntryForm.tsx
@@ -10,9 +10,7 @@ import {
   Button,
   DialogContent,
   DialogTitle,
-  IconButton,
   Box,
-  Tooltip,
 } from '@mui/material';
 import { EVENT_TYPE, EventEntry } from '@shared/data/EventEntry';
 import { addHours, addMinutes, differenceInMinutes, startOfDay } from 'date-fns';
@@ -27,7 +25,6 @@ import { TYPES } from '@renderer/types';
 import { AppError } from '@shared/errors/AppError';
 import AppContext from '../AppContext';
 import { styled } from '@mui/system';
-import { GoSidebarCollapse, GoSidebarExpand } from 'react-icons/go';
 import { ActivityTimeline } from './ActivityTimeline';
 
 export const FORM_MODE = {
@@ -154,11 +151,10 @@ const EventEntryForm = ({
     }
   }, [initialInterval, start, mode, setValue]);
 
-  const [showActivityTimeLine, setShowActivityTimeLine] = useState(false);
   const [dialogStyle, setDialogStyle] = useState({});
 
   useEffect(() => {
-    if (EVENT_TYPE.ACTUAL === eventType && showActivityTimeLine) {
+    if (EVENT_TYPE.ACTUAL === eventType) {
       setDialogStyle({
         maxWidth: 800,
         transition: 'width 0.5s ease, transform 0.5s ease',
@@ -169,11 +165,7 @@ const EventEntryForm = ({
         transition: 'width 0.5s ease, transform 0.5s ease',
       });
     }
-  }, [showActivityTimeLine, eventType]);
-
-  const handleShowActivityTimeLine = (): void => {
-    setShowActivityTimeLine(!showActivityTimeLine);
-  };
+  }, [eventType]);
 
   const handleFormSubmit = async (data): Promise<void> => {
     console.log('EventForm handleFormSubmit called with:', data);
@@ -261,39 +253,16 @@ const EventEntryForm = ({
           </DialogTitle>
           <CustomDialogContent>
             <Grid container spacing={2}>
-              <Grid item>
-                {EVENT_TYPE.ACTUAL === eventType && (
-                  <Tooltip
-                    title={
-                      showActivityTimeLine ? 'アクティビティを閉じる' : 'アクティビティを表示する'
-                    }
-                  >
-                    <IconButton
-                      edge="end"
-                      color="inherit"
-                      onClick={handleShowActivityTimeLine}
-                      aria-label="show timeline"
-                    >
-                      {showActivityTimeLine ? <GoSidebarExpand /> : <GoSidebarCollapse />}
-                    </IconButton>
-                  </Tooltip>
-                )}
-              </Grid>
-              {showActivityTimeLine && (
-                <Grid item xs={5}>
-                  <Paper
-                    variant="outlined"
-                    sx={{ maxHeight: 'calc(34rem - 4px)', overflowY: 'scroll' }}
-                  >
-                    <ActivityTimeline
-                      selectedDate={targetDate}
-                      startTime={start || targetDate}
-                      endTime={end || targetDate}
-                    />
-                  </Paper>
+              {EVENT_TYPE.ACTUAL === eventType && (
+                <Grid item xs={6}>
+                  <ActivityTimeline
+                    selectedDate={targetDate}
+                    focusTimeStart={start || targetDate}
+                    focusTimeEnd={end || targetDate}
+                  />
                 </Grid>
               )}
-              <Grid item xs={showActivityTimeLine ? 6 : 11}>
+              <Grid item xs={EVENT_TYPE.ACTUAL === eventType ? 6 : 12}>
                 <Paper variant="outlined">
                   <Grid container spacing={2} padding={2}>
                     <Grid item xs={12}>

--- a/src/renderer/src/services/EventTimeCell.ts
+++ b/src/renderer/src/services/EventTimeCell.ts
@@ -239,14 +239,22 @@ export class GitHubEventTimeCell extends EventTimeCell {
       const p = event.payload;
       const issue = p.issue as Record<string, unknown>;
       summary = `Issue`;
-      description = `${p.action} #${issue.number} ${issue.title}: ${issue.body}`;
+      if (p.action === 'closed') {
+        description = `${p.action} #${issue.number} ${issue.title}`;
+      } else {
+        description = `${p.action} #${issue.number} ${issue.title}: ${issue.body}`;
+      }
     } else if (event.type === 'PullRequestEvent') {
       // Pull Requestに関連するアクティビティ
       // payload: ?
       const p = event.payload;
       const pr = p.pull_request as Record<string, unknown>;
       summary = `PR`;
-      description = `${p.action} #${p.number} ${pr.title}: ${pr.body}`;
+      if (p.action === 'closed') {
+        description = `${p.action} #${p.number} ${pr.title}`;
+      } else {
+        description = `${p.action} #${p.number} ${pr.title}: ${pr.body}`;
+      }
     } else if (event.type === 'PullRequestReviewCommentEvent') {
       // Pull Requestの統合diff中のPull Requestレビューコメントに関連するアクティビティ
       // payload: ?


### PR DESCRIPTION
Issue: #122 

- 実績のダイアログにはアクティビティのタイムラインを常時表示する
- GitHubイベントとアクティビティを別々のタイムラインアイテムで実装
- GitHubイベントの表示を改良