### PR TITLE
feat: #79 1日の開始時間を設定可能にする

### DIFF
--- a/src/main/services/EventEntryServiceImpl.ts
+++ b/src/main/services/EventEntryServiceImpl.ts
@@ -1,4 +1,3 @@
-import mainContainer from '@main/inversify.config';
 import { EventEntry } from '@shared/data/EventEntry';
 import { IEventEntryService } from './IEventEntryService';
 import { inject, injectable } from 'inversify';
@@ -11,7 +10,9 @@ import { DateUtil } from '@shared/utils/DateUtil';
 export class EventEntryServiceImpl implements IEventEntryService {
   constructor(
     @inject(TYPES.DataSource)
-    private readonly dataSource: DataSource<EventEntry>
+    private readonly dataSource: DataSource<EventEntry>,
+    @inject(TYPES.DateUtil)
+    private readonly dateUtil: DateUtil
   ) {
     this.dataSource.createDb(this.tableName, [{ fieldName: 'id', unique: true }]);
   }
@@ -38,7 +39,7 @@ export class EventEntryServiceImpl implements IEventEntryService {
   }
 
   async save(data: EventEntry): Promise<EventEntry> {
-    data.updated = mainContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate();
+    data.updated = this.dateUtil.getCurrentDate();
     EventEntryFactory.validate(data);
     return await this.dataSource.upsert(this.tableName, data);
   }

--- a/src/main/services/UserPreferenceStoreServiceImpl.ts
+++ b/src/main/services/UserPreferenceStoreServiceImpl.ts
@@ -28,6 +28,8 @@ export class UserPreferenceStoreServiceImpl implements IUserPreferenceStoreServi
       syncGoogleCalendar: false,
       calendars: [],
 
+      startHourLocal: 6,
+
       speakEvent: false,
       speakEventTimeOffset: 10,
       speakEventTextTemplate: '{TITLE} まで {READ_TIME_OFFSET} 秒前です',

--- a/src/main/services/UserPreferenceStoreServiceImpl.ts
+++ b/src/main/services/UserPreferenceStoreServiceImpl.ts
@@ -1,4 +1,3 @@
-import mainContainer from '@main/inversify.config';
 import { UserPreference } from '@shared/data/UserPreference';
 import { IUserPreferenceStoreService } from './IUserPreferenceStoreService';
 import { inject, injectable } from 'inversify';
@@ -10,7 +9,9 @@ import { DateUtil } from '@shared/utils/DateUtil';
 export class UserPreferenceStoreServiceImpl implements IUserPreferenceStoreService {
   constructor(
     @inject(TYPES.DataSource)
-    private readonly dataSource: DataSource<UserPreference>
+    private readonly dataSource: DataSource<UserPreference>,
+    @inject(TYPES.DateUtil)
+    private readonly dateUtil: DateUtil
   ) {
     this.dataSource.createDb(this.tableName, [{ fieldName: 'userId', unique: true }]);
   }
@@ -30,7 +31,7 @@ export class UserPreferenceStoreServiceImpl implements IUserPreferenceStoreServi
       syncGoogleCalendar: false,
       calendars: [],
 
-      startHourLocal: 6,
+      startHourLocal: 9,
 
       speakEvent: false,
       speakEventTimeOffset: 10,
@@ -42,7 +43,7 @@ export class UserPreferenceStoreServiceImpl implements IUserPreferenceStoreServi
 
       muteWhileInMeeting: true,
 
-      updated: mainContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate(),
+      updated: this.dateUtil.getCurrentDate(),
     };
   }
 
@@ -55,7 +56,7 @@ export class UserPreferenceStoreServiceImpl implements IUserPreferenceStoreServi
   }
 
   async save(data: UserPreference): Promise<UserPreference> {
-    data.updated = mainContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate();
+    data.updated = this.dateUtil.getCurrentDate();
     return await this.dataSource.upsert(this.tableName, data);
   }
 }

--- a/src/main/services/UserPreferenceStoreServiceImpl.ts
+++ b/src/main/services/UserPreferenceStoreServiceImpl.ts
@@ -1,8 +1,10 @@
+import mainContainer from '@main/inversify.config';
 import { UserPreference } from '@shared/data/UserPreference';
 import { IUserPreferenceStoreService } from './IUserPreferenceStoreService';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '@main/types';
 import { DataSource } from './DataSource';
+import { DateUtil } from '@shared/utils/DateUtil';
 
 @injectable()
 export class UserPreferenceStoreServiceImpl implements IUserPreferenceStoreService {
@@ -40,7 +42,7 @@ export class UserPreferenceStoreServiceImpl implements IUserPreferenceStoreServi
 
       muteWhileInMeeting: true,
 
-      updated: new Date(),
+      updated: mainContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate(),
     };
   }
 
@@ -53,7 +55,7 @@ export class UserPreferenceStoreServiceImpl implements IUserPreferenceStoreServi
   }
 
   async save(data: UserPreference): Promise<UserPreference> {
-    data.updated = new Date();
+    data.updated = mainContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate();
     return await this.dataSource.upsert(this.tableName, data);
   }
 }

--- a/src/main/services/WindowLogServiceImpl.ts
+++ b/src/main/services/WindowLogServiceImpl.ts
@@ -1,4 +1,3 @@
-import mainContainer from '@main/inversify.config';
 import { WindowLog } from '@shared/data/WindowLog';
 import { IWindowLogService } from './IWindowLogService';
 import { inject, injectable } from 'inversify';
@@ -10,7 +9,9 @@ import { DateUtil } from '@shared/utils/DateUtil';
 export class WindowLogServiceImpl implements IWindowLogService {
   constructor(
     @inject(TYPES.DataSource)
-    private readonly dataSource: DataSource<WindowLog>
+    private readonly dataSource: DataSource<WindowLog>,
+    @inject(TYPES.DateUtil)
+    private readonly dateUtil: DateUtil
   ) {
     this.dataSource.createDb(this.tableName, [{ fieldName: 'id', unique: true }]);
   }
@@ -40,7 +41,7 @@ export class WindowLogServiceImpl implements IWindowLogService {
     windowTitle: string,
     path?: string | null
   ): Promise<WindowLog> {
-    const now = mainContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate();
+    const now = this.dateUtil.getCurrentDate();
     return {
       id: this.dataSource.generateUniqueId(),
       basename: basename,

--- a/src/main/services/__tests__/EventEntryServiceImpl.test.ts
+++ b/src/main/services/__tests__/EventEntryServiceImpl.test.ts
@@ -1,4 +1,3 @@
-import mainContainer from '@main/inversify.config';
 import { TestDataSource } from './TestDataSource';
 import { EventEntryServiceImpl } from '../EventEntryServiceImpl';
 import { EVENT_TYPE, EventEntry } from '@shared/data/EventEntry';
@@ -6,7 +5,6 @@ import { DataSource } from '../DataSource';
 import { EventDateTimeFixture, EventEntryFixture } from '@shared/data/__tests__/EventEntryFixture';
 import { assert } from 'console';
 import { DateUtil } from '@shared/utils/DateUtil';
-import { TYPES } from '@main/types';
 
 describe('EventServiceEntryImpl', () => {
   let service: EventEntryServiceImpl;
@@ -15,9 +13,9 @@ describe('EventServiceEntryImpl', () => {
 
   beforeEach(async () => {
     jest.resetAllMocks();
-    dateUtil = mainContainer.get<DateUtil>(TYPES.DateUtil);
+    dateUtil = new DateUtil();
     dataSource = new TestDataSource<EventEntry>();
-    service = new EventEntryServiceImpl(dataSource);
+    service = new EventEntryServiceImpl(dataSource, dateUtil);
     dataSource.delete(service.tableName, {});
     const count = await dataSource.count(service.tableName, {});
     assert(count === 0);

--- a/src/main/services/__tests__/WindowLogServiceImpl.test.ts
+++ b/src/main/services/__tests__/WindowLogServiceImpl.test.ts
@@ -4,15 +4,18 @@ import { WindowLogFixture } from '@shared/data/__tests__/WindowLogFixture';
 import { assert } from 'console';
 import { WindowLogServiceImpl } from '../WindowLogServiceImpl';
 import { WindowLog } from '@shared/data/WindowLog';
+import { DateUtil } from '@shared/utils/DateUtil';
 
 describe('WindowLogServiceEntryImpl', () => {
   let service: WindowLogServiceImpl;
   let dataSource: DataSource<WindowLog>;
+  let dateUtil: DateUtil;
 
   beforeEach(async () => {
     jest.resetAllMocks();
     dataSource = new TestDataSource<WindowLog>();
-    service = new WindowLogServiceImpl(dataSource);
+    dateUtil = new DateUtil();
+    service = new WindowLogServiceImpl(dataSource, dateUtil);
     dataSource.delete(service.tableName, {});
     const count = await dataSource.count(service.tableName, {});
     assert(count === 0);

--- a/src/renderer/src/components/settings/GeneralSetting.tsx
+++ b/src/renderer/src/components/settings/GeneralSetting.tsx
@@ -71,6 +71,7 @@ export const GeneralSetting = (): JSX.Element => {
       );
       const userPreference = await userPreferenceProxy.getOrCreate(userDetails.userId);
       const updateData = { ...userPreference, ...data };
+      updateData.startHourLocal = Number(updateData.startHourLocal);
       updateData.speakEvent = Boolean(updateData.speakEvent);
       updateData.speakEventTimeOffset = Number(updateData.speakEventTimeOffset);
       updateData.speakTimeSignal = Boolean(updateData.speakTimeSignal);
@@ -120,6 +121,37 @@ export const GeneralSetting = (): JSX.Element => {
                         </FormControl>
                       )}
                     />
+                  </Grid>
+                </Grid>
+              </Paper>
+            </Grid>
+            <Grid item xs={12}>
+              <Paper variant="outlined">
+                <Grid container spacing={2} padding={2}>
+                  <Grid item>
+                    <Controller
+                      name="startHourLocal"
+                      control={control}
+                      defaultValue={userPreference?.startHourLocal}
+                      rules={{
+                        required: '入力してください。',
+                        min: { value: 0, message: '0以上の値を入力してください。' },
+                        max: { value: 23, message: '23以下の値を入力してください。' },
+                      }}
+                      render={({ field, fieldState: { error } }): React.ReactElement => (
+                        <>
+                          <FormLabel component="legend">1日の開始時間</FormLabel>
+                          <TextField
+                            {...field}
+                            type="number"
+                            error={!!error}
+                            helperText={error?.message}
+                            variant="outlined"
+                          />
+                          <FormHelperText>0～23の値を入力してください。</FormHelperText>
+                        </>
+                      )}
+                    ></Controller>
                   </Grid>
                 </Grid>
               </Paper>

--- a/src/renderer/src/components/settings/GeneralSetting.tsx
+++ b/src/renderer/src/components/settings/GeneralSetting.tsx
@@ -147,6 +147,12 @@ export const GeneralSetting = (): JSX.Element => {
                             error={!!error}
                             helperText={error?.message}
                             variant="outlined"
+                            InputProps={{
+                              inputProps: {
+                                min: 0,
+                                max: 23,
+                              },
+                            }}
                           />
                           <FormHelperText>0～23の値を入力してください。</FormHelperText>
                         </>

--- a/src/renderer/src/components/timeTable/ActivitySlot.tsx
+++ b/src/renderer/src/components/timeTable/ActivitySlot.tsx
@@ -12,7 +12,6 @@ import {
 } from '@mui/material';
 import { ActivityEvent } from '@shared/data/ActivityEvent';
 import {
-  DEFAULT_START_HOUR_LOCAL,
   ParentRefContext,
   SelectedDateContext,
   TIME_CELL_HEIGHT,
@@ -67,7 +66,7 @@ export const ActivitySlot = ({ eventTimeCell, children }: ActivitySlotProps): JS
   const targetDate = useContext(SelectedDateContext);
   // 1時間の枠の高さ
   const cellHeightPx = (theme.typography.fontSize + 2) * TIME_CELL_HEIGHT;
-  const startHourLocal = userPreference?.startHourLocal ?? DEFAULT_START_HOUR_LOCAL;
+  const startHourLocal = userPreference?.startHourLocal;
   const [slotRect, setSlotRect] = useState<SlotRect>({
     x: 0,
     y: 0,
@@ -85,6 +84,9 @@ export const ActivitySlot = ({ eventTimeCell, children }: ActivitySlotProps): JS
       eventTimeCell: EventTimeCell,
       prevRect: SlotRect
     ): void => {
+      if (!targetDate || !startHourLocal) {
+        return;
+      }
       const start =
         eventTimeCell.cellFrameStart < targetDate ? targetDate : eventTimeCell.cellFrameStart;
       const end =

--- a/src/renderer/src/components/timeTable/ActivitySlot.tsx
+++ b/src/renderer/src/components/timeTable/ActivitySlot.tsx
@@ -11,7 +11,12 @@ import {
   useTheme,
 } from '@mui/material';
 import { ActivityEvent } from '@shared/data/ActivityEvent';
-import { ParentRefContext, TIME_CELL_HEIGHT, convertDateToTableOffset } from './common';
+import {
+  DEFAULT_START_HOUR_LOCAL,
+  ParentRefContext,
+  TIME_CELL_HEIGHT,
+  convertDateToTableOffset,
+} from './common';
 import {
   ActivityEventTimeCell,
   EventTimeCell,
@@ -20,6 +25,7 @@ import {
 import { useContext, useEffect, useState } from 'react';
 import { CheckCircle } from '@mui/icons-material';
 import { getOptimalTextColor } from '@renderer/utils/ColotUtil';
+import { useUserPreference } from '@renderer/hooks/useUserPreference';
 
 interface SlotRect {
   x: number;
@@ -53,6 +59,7 @@ interface ActivitySlotProps {
  * 尚、Tooltip の中身は、ActivityDetailsStepper で構成する。
  */
 export const ActivitySlot = ({ eventTimeCell, children }: ActivitySlotProps): JSX.Element => {
+  const { userPreference } = useUserPreference();
   const parentRef = useContext(ParentRefContext);
   const theme = useTheme();
   // 1時間の枠の高さ
@@ -61,7 +68,12 @@ export const ActivitySlot = ({ eventTimeCell, children }: ActivitySlotProps): JS
   const start = eventTimeCell.cellFrameStart;
   const end = eventTimeCell.cellFrameEnd;
   // レーンの中の表示開始位置（時間）
-  const startHourOffset = convertDateToTableOffset(start);
+  const startHourOffset = convertDateToTableOffset(
+    start,
+    userPreference?.startHourLocal != null
+      ? userPreference.startHourLocal
+      : DEFAULT_START_HOUR_LOCAL
+  );
   let durationHours = (end.getTime() - start.getTime()) / 3600000;
   if (startHourOffset + durationHours > 24) {
     durationHours = 24 - startHourOffset;
@@ -85,7 +97,13 @@ export const ActivitySlot = ({ eventTimeCell, children }: ActivitySlotProps): JS
     ): void => {
       const width = (parentWidth - 2) / eventTimeCell.overlappingCount;
       const x = width * eventTimeCell.overlappingIndex;
-      const y = convertDateToTableOffset(eventTimeCell.cellFrameStart) * cellHeightPx;
+      const y =
+        convertDateToTableOffset(
+          eventTimeCell.cellFrameStart,
+          userPreference?.startHourLocal != null
+            ? userPreference.startHourLocal
+            : DEFAULT_START_HOUR_LOCAL
+        ) * cellHeightPx;
       const newDurationHours =
         (eventTimeCell.cellFrameEnd.getTime() - eventTimeCell.cellFrameStart.getTime()) / 3600000;
       const height = newDurationHours * cellHeightPx;

--- a/src/renderer/src/components/timeTable/EventEntryForm.tsx
+++ b/src/renderer/src/components/timeTable/EventEntryForm.tsx
@@ -51,7 +51,7 @@ interface EventEntryFormProps {
   isOpen: boolean;
   mode: FORM_MODE;
   eventType: EVENT_TYPE;
-  targetDate: Date;
+  targetDate?: Date;
   startHour: number;
   eventEntry?: EventEntry;
   onSubmit: (eventEntry: EventEntry) => Promise<void>;
@@ -82,8 +82,8 @@ const EventEntryForm = ({
 }: EventEntryFormProps): JSX.Element => {
   console.log('EventEntryForm', isOpen, eventEntry);
   const defaultValues = { ...eventEntry };
-  const targetDateTime = targetDate.getTime();
-  if (mode === FORM_MODE.NEW) {
+  const targetDateTime = targetDate?.getTime();
+  if (targetDate && mode === FORM_MODE.NEW) {
     defaultValues.start = {
       dateTime: addHours(startOfDay(targetDate), startHour),
     };
@@ -104,7 +104,7 @@ const EventEntryForm = ({
   useEffect(() => {
     if (mode === FORM_MODE.EDIT) {
       reset(eventEntry);
-    } else {
+    } else if (targetDateTime) {
       // 新規のときは、開始時間と終了時間をクリックした
       // 時間帯の1時間で初期化する
       const targetDate = new Date(targetDateTime);
@@ -253,7 +253,7 @@ const EventEntryForm = ({
           </DialogTitle>
           <CustomDialogContent>
             <Grid container spacing={2}>
-              {EVENT_TYPE.ACTUAL === eventType && (
+              {EVENT_TYPE.ACTUAL === eventType && targetDate && (
                 <Grid item xs={6}>
                   <ActivityTimeline
                     selectedDate={targetDate}

--- a/src/renderer/src/components/timeTable/EventSlot.tsx
+++ b/src/renderer/src/components/timeTable/EventSlot.tsx
@@ -160,6 +160,10 @@ export const EventSlot = ({
     startHourLocal,
   ]);
 
+  if (!targetDate || !startHourLocal) {
+    return <></>;
+  }
+
   const handleClick = (): void => {
     console.log('onClick isDragging', isDragging);
     if (!isDragging && onClick) {
@@ -169,9 +173,6 @@ export const EventSlot = ({
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleDragStart = (_e, d): void => {
-    if (!startHourLocal) {
-      return;
-    }
     setIsDragging(true);
     const { x, y } = d;
     setDragStartPosition({ x, y });
@@ -180,9 +181,6 @@ export const EventSlot = ({
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleDragStop = (_e, d): void => {
-    if (!startHourLocal) {
-      return;
-    }
     console.log('handleDragStop', d);
     setTimeout(() => {
       setIsDragging(false);
@@ -280,7 +278,7 @@ export const EventSlot = ({
       }}
       onClick={handleClick}
       enableResizing={{
-        bottom: !!startHourLocal,
+        bottom: true,
         bottomLeft: false,
         bottomRight: false,
         left: false,
@@ -289,7 +287,6 @@ export const EventSlot = ({
         topLeft: false,
         topRight: false,
       }}
-      disableDragging={!startHourLocal}
       dragGrid={[1, cellHeightPx / 4]}
       resizeGrid={[1, cellHeightPx / 4]}
       size={{

--- a/src/renderer/src/components/timeTable/EventSlot.tsx
+++ b/src/renderer/src/components/timeTable/EventSlot.tsx
@@ -1,6 +1,5 @@
 import { useTheme } from '@mui/material';
 import {
-  DEFAULT_START_HOUR_LOCAL,
   ParentRefContext,
   SelectedDateContext,
   TIME_CELL_HEIGHT,
@@ -79,7 +78,7 @@ export const EventSlot = ({
   const targetDate = useContext(SelectedDateContext);
   // 1時間の枠の高さ
   const cellHeightPx = (theme.typography.fontSize + 2) * TIME_CELL_HEIGHT;
-  const startHourLocal = userPreference?.startHourLocal ?? DEFAULT_START_HOUR_LOCAL;
+  const startHourLocal = userPreference?.startHourLocal;
   // イベントの高さ
   const [dragStartPosition, setDragStartPosition] = useState({ x: 0, y: 0 });
   const [dragDropResizeState, setDragDropResizeState] = useState<DragDropResizeState>({
@@ -97,6 +96,9 @@ export const EventSlot = ({
   // calc() による設定は出来なかったので、親Elementのpixel数から計算することにした。
   // ResizeObserverを使うのは、画面のサイズが変わったときにも再計算させるため。
   useEffect(() => {
+    if (!targetDate || !startHourLocal) {
+      return;
+    }
     const recalcDDRState = (
       parentWidth: number,
       eventTimeCell: EventEntryTimeCell,
@@ -167,6 +169,9 @@ export const EventSlot = ({
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleDragStart = (_e, d): void => {
+    if (!startHourLocal) {
+      return;
+    }
     setIsDragging(true);
     const { x, y } = d;
     setDragStartPosition({ x, y });
@@ -175,6 +180,9 @@ export const EventSlot = ({
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleDragStop = (_e, d): void => {
+    if (!startHourLocal) {
+      return;
+    }
     console.log('handleDragStop', d);
     setTimeout(() => {
       setIsDragging(false);
@@ -272,7 +280,7 @@ export const EventSlot = ({
       }}
       onClick={handleClick}
       enableResizing={{
-        bottom: true,
+        bottom: !!startHourLocal,
         bottomLeft: false,
         bottomRight: false,
         left: false,
@@ -281,6 +289,7 @@ export const EventSlot = ({
         topLeft: false,
         topRight: false,
       }}
+      disableDragging={!startHourLocal}
       dragGrid={[1, cellHeightPx / 4]}
       resizeGrid={[1, cellHeightPx / 4]}
       size={{

--- a/src/renderer/src/components/timeTable/EventSlot.tsx
+++ b/src/renderer/src/components/timeTable/EventSlot.tsx
@@ -1,10 +1,16 @@
 import { useTheme } from '@mui/material';
-import { ParentRefContext, TIME_CELL_HEIGHT, convertDateToTableOffset } from './common';
+import {
+  DEFAULT_START_HOUR_LOCAL,
+  ParentRefContext,
+  TIME_CELL_HEIGHT,
+  convertDateToTableOffset,
+} from './common';
 import { Rnd } from 'react-rnd';
 import { useContext, useEffect, useState } from 'react';
 import { addMinutes, differenceInMinutes } from 'date-fns';
 import { EventEntryTimeCell } from '@renderer/services/EventTimeCell';
 import { getOptimalTextColor } from '@renderer/utils/ColotUtil';
+import { useUserPreference } from '@renderer/hooks/useUserPreference';
 
 export interface DragDropResizeState {
   eventTimeCell: EventEntryTimeCell;
@@ -66,6 +72,7 @@ export const EventSlot = ({
   backgroundColor,
 }: EventSlotProps): JSX.Element => {
   console.log('EventSlot called with:', eventTimeCell.summary);
+  const { userPreference } = useUserPreference();
   const parentRef = useContext(ParentRefContext);
   const theme = useTheme();
   // 1時間の枠の高さ
@@ -74,7 +81,12 @@ export const EventSlot = ({
   const start = eventTimeCell.cellFrameStart;
   const end = eventTimeCell.cellFrameEnd;
   // レーンの中の表示開始位置（時間）
-  const startHourOffset = convertDateToTableOffset(start);
+  const startHourOffset = convertDateToTableOffset(
+    start,
+    userPreference?.startHourLocal != null
+      ? userPreference.startHourLocal
+      : DEFAULT_START_HOUR_LOCAL
+  );
   let durationHours = (end.getTime() - start.getTime()) / 3600000;
   if (startHourOffset + durationHours > 24) {
     durationHours = 24 - startHourOffset;
@@ -105,7 +117,13 @@ export const EventSlot = ({
     ): void => {
       const newWidth = (parentWidth - theme.typography.fontSize) / eventTimeCell.overlappingCount;
       const newOffsetX = newWidth * eventTimeCell.overlappingIndex;
-      const newOffsetY = convertDateToTableOffset(eventTimeCell.cellFrameStart) * cellHeightPx;
+      const newOffsetY =
+        convertDateToTableOffset(
+          eventTimeCell.cellFrameStart,
+          userPreference?.startHourLocal != null
+      ? userPreference.startHourLocal
+      : DEFAULT_START_HOUR_LOCAL
+        ) * cellHeightPx;
       const newHours =
         (eventTimeCell.cellFrameEnd.getTime() - eventTimeCell.cellFrameStart.getTime()) / 3600000;
       const newState: DragDropResizeState = {
@@ -187,7 +205,12 @@ export const EventSlot = ({
     newDDRState.eventTimeCell = newDDRState.eventTimeCell.replaceTime(newStartTime, newEndTime);
 
     newDDRState.offsetY =
-      convertDateToTableOffset(newDDRState.eventTimeCell.cellFrameStart) * cellHeightPx;
+      convertDateToTableOffset(
+        newDDRState.eventTimeCell.cellFrameStart,
+        userPreference?.startHourLocal != null
+      ? userPreference.startHourLocal
+      : DEFAULT_START_HOUR_LOCAL
+      ) * cellHeightPx;
     setDragDropResizeState(newDDRState);
     onDragStop(newDDRState);
     setDragStartPosition({ x: newDDRState.offsetX, y: newDDRState.offsetY });

--- a/src/renderer/src/components/timeTable/TimeLane.tsx
+++ b/src/renderer/src/components/timeTable/TimeLane.tsx
@@ -1,6 +1,6 @@
 import { EventEntry } from '@shared/data/EventEntry';
 import { DragDropResizeState, EventSlot } from './EventSlot';
-import { DEFAULT_START_HOUR_LOCAL, ParentRefContext, TIME_CELL_HEIGHT, TimeCell } from './common';
+import { ParentRefContext, TIME_CELL_HEIGHT, TimeCell } from './common';
 import { Box } from '@mui/material';
 import { useRef } from 'react';
 import React from 'react';
@@ -32,6 +32,7 @@ export const TimeLane = ({
   onResizeStop,
 }: TimeLaneProps): JSX.Element => {
   const { userPreference } = useUserPreference();
+  const startHourLocal = userPreference?.startHourLocal;
 
   return (
     <TimeLaneContainer name={name}>
@@ -48,25 +49,16 @@ export const TimeLane = ({
           <EventSlotText eventTimeCell={oe} />
         </EventSlot>
       ))}
-      {Array.from({ length: 24 }).map((_, hour, self) => (
-        <TimeCell
-          key={
-            hour +
-            (userPreference?.startHourLocal != null
-              ? userPreference.startHourLocal
-              : DEFAULT_START_HOUR_LOCAL)
-          }
-          isBottom={hour === self.length - 1}
-          onClick={(): void => {
-            onAddEventEntry(
-              hour +
-                (userPreference?.startHourLocal != null
-                  ? userPreference.startHourLocal
-                  : DEFAULT_START_HOUR_LOCAL)
-            );
-          }}
-        />
-      ))}
+      {startHourLocal &&
+        Array.from({ length: 24 }).map((_, hour, self) => (
+          <TimeCell
+            key={hour + startHourLocal}
+            isBottom={hour === self.length - 1}
+            onClick={(): void => {
+              onAddEventEntry(hour + startHourLocal);
+            }}
+          />
+        ))}
     </TimeLaneContainer>
   );
 };

--- a/src/renderer/src/components/timeTable/TimeLane.tsx
+++ b/src/renderer/src/components/timeTable/TimeLane.tsx
@@ -1,11 +1,12 @@
 import { EventEntry } from '@shared/data/EventEntry';
 import { DragDropResizeState, EventSlot } from './EventSlot';
-import { ParentRefContext, TIME_CELL_HEIGHT, TimeCell, startHourLocal } from './common';
+import { DEFAULT_START_HOUR_LOCAL, ParentRefContext, TIME_CELL_HEIGHT, TimeCell } from './common';
 import { Box } from '@mui/material';
 import { useRef } from 'react';
 import React from 'react';
 import { EventEntryTimeCell } from '@renderer/services/EventTimeCell';
 import { EventSlotText } from './EventSlotText';
+import { useUserPreference } from '@renderer/hooks/useUserPreference';
 
 interface TimeLaneProps {
   name: string;
@@ -30,6 +31,8 @@ export const TimeLane = ({
   onDragStop,
   onResizeStop,
 }: TimeLaneProps): JSX.Element => {
+  const { userPreference } = useUserPreference();
+
   return (
     <TimeLeneContainer name={name}>
       {overlappedEvents.map((oe) => (
@@ -47,10 +50,20 @@ export const TimeLane = ({
       ))}
       {Array.from({ length: 24 }).map((_, hour, self) => (
         <TimeCell
-          key={hour + startHourLocal}
+          key={
+            hour +
+            (userPreference?.startHourLocal != null
+              ? userPreference.startHourLocal
+              : DEFAULT_START_HOUR_LOCAL)
+          }
           isBottom={hour === self.length - 1}
           onClick={(): void => {
-            onAddEventEntry(hour + startHourLocal);
+            onAddEventEntry(
+              hour +
+                (userPreference?.startHourLocal != null
+                  ? userPreference.startHourLocal
+                  : DEFAULT_START_HOUR_LOCAL)
+            );
           }}
         />
       ))}

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -8,7 +8,7 @@ import { useContext, useEffect, useState } from 'react';
 import EventEntryForm, { FORM_MODE } from './EventEntryForm';
 import { useEventEntries } from '@renderer/hooks/useEventEntries';
 import { DatePicker } from '@mui/x-date-pickers';
-import { startHourLocal, HeaderCell, TimeCell } from './common';
+import { HeaderCell, TimeCell, DEFAULT_START_HOUR_LOCAL } from './common';
 import { useActivityEvents } from '@renderer/hooks/useActivityEvents';
 import { TimeLane, TimeLeneContainer } from './TimeLane';
 import { DragDropResizeState } from './EventSlot';
@@ -260,7 +260,11 @@ const TimeTable = (): JSX.Element => {
           <TimeLeneContainer name={'axis'}>
             {Array.from({ length: 24 }).map((_, hour, self) => (
               <TimeCell key={hour} isBottom={hour === self.length - 1}>
-                {(hour + startHourLocal) % 24}
+                {(hour +
+                  (userPreference?.startHourLocal != null
+                    ? userPreference.startHourLocal
+                    : DEFAULT_START_HOUR_LOCAL)) %
+                  24}
               </TimeCell>
             ))}
           </TimeLeneContainer>

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -39,11 +39,13 @@ const TimeTable = (): JSX.Element => {
   const { userPreference, loading: loadingUserPreference } = useUserPreference();
   const showCalendarSyncButton = !loadingUserPreference && userPreference?.syncGoogleCalendar;
   const [isCalendarSyncing, setIsCalendarSyncing] = useState(false);
-  const startHourLocal = userPreference?.startHourLocal ?? DEFAULT_START_HOUR_LOCAL;
 
+  const startHourLocal = userPreference?.startHourLocal ?? DEFAULT_START_HOUR_LOCAL;
   const now = rendererContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate();
   // 日付は1日の開始時刻で保存する
-  const [selectedDate, setSelectedDate] = useState(getStartDate(now, startHourLocal));
+  const today = getStartDate(now, startHourLocal);
+  const [selectedDate, setSelectedDate] = useState<Date>(today);
+
   const {
     events: eventEntries,
     overlappedPlanEvents,
@@ -68,6 +70,12 @@ const TimeTable = (): JSX.Element => {
 
   const { isAuthenticated: isGitHubAuthenticated } = useGitHubAuth();
   const [isGitHubSyncing, setIsGitHubSyncing] = useState(false);
+
+  useEffect(() => {
+    // userPreferense が読み込まれた後に反映させる
+    setSelectedDate(today);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [startHourLocal]);
 
   useEffect(() => {
     // ハンドラ

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -100,7 +100,7 @@ const TimeTable = (): JSX.Element => {
     };
   }, [refreshEventEntries]);
 
-  if (eventEntries === null || activityEvents === null) {
+  if (eventEntries === null || activityEvents === null || !startHourLocal) {
     return <div>Loading...</div>;
   }
 
@@ -135,11 +135,9 @@ const TimeTable = (): JSX.Element => {
   };
 
   const handleToday = (): void => {
-    if (startHourLocal) {
-      const now = rendererContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate();
-      // 日付は1日の開始時刻で保存する
-      setSelectedDate(getStartDate(now, startHourLocal));
-    }
+    const now = rendererContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate();
+    // 日付は1日の開始時刻で保存する
+    setSelectedDate(getStartDate(now, startHourLocal));
   };
 
   const handlePrevDay = (): void => {
@@ -156,7 +154,7 @@ const TimeTable = (): JSX.Element => {
 
   // 日付が変更されたときにイベントを再フェッチする
   const handleDateChange = (date: Date | null): void => {
-    if (date !== null && startHourLocal) {
+    if (date !== null) {
       // 日付は1日の開始時刻で保存する
       setSelectedDate(getStartDate(date, startHourLocal));
     }
@@ -281,12 +279,11 @@ const TimeTable = (): JSX.Element => {
           <Grid item xs={1}>
             <HeaderCell></HeaderCell>
             <TimeLaneContainer name={'axis'}>
-              {startHourLocal &&
-                Array.from({ length: 24 }).map((_, hour, self) => (
-                  <TimeCell key={hour} isBottom={hour === self.length - 1}>
-                    {(hour + startHourLocal) % 24}
-                  </TimeCell>
-                ))}
+              {Array.from({ length: 24 }).map((_, hour, self) => (
+                <TimeCell key={hour} isBottom={hour === self.length - 1}>
+                  {(hour + startHourLocal) % 24}
+                </TimeCell>
+              ))}
             </TimeLaneContainer>
           </Grid>
           <Grid item xs={4}>

--- a/src/renderer/src/components/timeTable/common.ts
+++ b/src/renderer/src/components/timeTable/common.ts
@@ -3,8 +3,6 @@ import { Box } from '@mui/material';
 import { addDays, differenceInMinutes, startOfDay } from 'date-fns';
 import React from 'react';
 
-export const DEFAULT_START_HOUR_LOCAL = 6;
-
 export const HEADER_CELL_HEIGHT = 2;
 
 export const TIME_CELL_HEIGHT = 3;
@@ -31,7 +29,7 @@ export const HeaderCell = styled(Cell)(({ theme }) => ({
 }));
 
 export const ParentRefContext = React.createContext<React.RefObject<HTMLDivElement> | null>(null);
-export const SelectedDateContext = React.createContext<Date>(new Date());
+export const SelectedDateContext = React.createContext<Date | undefined>(undefined);
 
 /**
  * 指定された日時における1日の開始日時を取得します。

--- a/src/renderer/src/components/timeTable/common.ts
+++ b/src/renderer/src/components/timeTable/common.ts
@@ -3,8 +3,7 @@ import { Box } from '@mui/material';
 import { differenceInMinutes, startOfDay } from 'date-fns';
 import React from 'react';
 
-// TODO 設定画面で設定できるようにする
-export const startHourLocal = 6;
+export const DEFAULT_START_HOUR_LOCAL = 6;
 
 export const HEADER_CELL_HEIGHT = 2;
 
@@ -45,9 +44,10 @@ export const ParentRefContext = React.createContext<React.RefObject<HTMLDivEleme
  * startHourLocal が 6:00 で date が 4:00 の場合は 22 を返す。
  *
  * @param date - オフセットを計算するための日時
+ * @param startHourLocal - 1日の開始時間
  * @returns 時間単位でのオフセット
  */
-export const convertDateToTableOffset = (date: Date): number => {
+export const convertDateToTableOffset = (date: Date, startHourLocal: number): number => {
   // 開始時間を日付の一部として考慮するために、日付の開始時間を取得します。
   const startDate = startOfDay(date);
 

--- a/src/renderer/src/hooks/useActivityEvents.ts
+++ b/src/renderer/src/hooks/useActivityEvents.ts
@@ -23,9 +23,6 @@ interface UseActivityEventsResult {
   refreshActivityEntries: () => void;
 }
 
-// TODO あとで preference で設定できるようにする
-const START_HOUR = 6;
-
 const useActivityEvents = (targetDate: Date): UseActivityEventsResult => {
   const [activityEvents, setActivityEvents] = React.useState<ActivityEvent[] | null>(null);
   const [githubEvents, setGitHubEvents] = React.useState<GitHubEvent[] | null>(null);
@@ -46,9 +43,8 @@ const useActivityEvents = (targetDate: Date): UseActivityEventsResult => {
   // 初期取得(再取得)
   const refreshActivityEntries = React.useCallback(async (): Promise<void> => {
     try {
-      const today = targetDate;
-      const startDate = new Date(today);
-      startDate.setHours(START_HOUR, 0, 0, 0);
+      // targetDateには一日の開始時間が渡される
+      const startDate = new Date(targetDate);
       const endDate = addDate(startDate, { days: 1 });
 
       const activityEventProxy = rendererContainer.get<IActivityEventProxy>(

--- a/src/renderer/src/hooks/useActivityEvents.ts
+++ b/src/renderer/src/hooks/useActivityEvents.ts
@@ -23,7 +23,7 @@ interface UseActivityEventsResult {
   refreshActivityEntries: () => void;
 }
 
-const useActivityEvents = (targetDate: Date): UseActivityEventsResult => {
+const useActivityEvents = (targetDate?: Date): UseActivityEventsResult => {
   const [activityEvents, setActivityEvents] = React.useState<ActivityEvent[] | null>(null);
   const [githubEvents, setGitHubEvents] = React.useState<GitHubEvent[] | null>(null);
   const [overlappedEvents, setOverlappedEvents] = React.useState<EventTimeCell[]>([]);
@@ -43,6 +43,9 @@ const useActivityEvents = (targetDate: Date): UseActivityEventsResult => {
   // 初期取得(再取得)
   const refreshActivityEntries = React.useCallback(async (): Promise<void> => {
     try {
+      if (!targetDate) {
+        return;
+      }
       // targetDateには一日の開始時間が渡される
       const startDate = new Date(targetDate);
       const endDate = addDate(startDate, { days: 1 });

--- a/src/renderer/src/hooks/useEventEntries.ts
+++ b/src/renderer/src/hooks/useEventEntries.ts
@@ -20,9 +20,6 @@ interface UseEventEntriesResult {
   refreshEventEntries: () => void;
 }
 
-// TODO あとで preference で設定できるようにする
-const START_HOUR = 6;
-
 const useEventEntries = (targetDate: Date): UseEventEntriesResult => {
   const { userDetails } = useContext(AppContext);
   const [events, setEvents] = React.useState<EventEntry[] | null>(null);
@@ -55,9 +52,8 @@ const useEventEntries = (targetDate: Date): UseEventEntriesResult => {
       return;
     }
     try {
-      const today = targetDate;
-      const startDate = new Date(today);
-      startDate.setHours(START_HOUR, 0, 0, 0);
+      // targetDateには1日の開始時間が渡される
+      const startDate = new Date(targetDate);
       const endDate = addDate(startDate, { days: 1 });
 
       const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);

--- a/src/renderer/src/hooks/useEventEntries.ts
+++ b/src/renderer/src/hooks/useEventEntries.ts
@@ -20,7 +20,7 @@ interface UseEventEntriesResult {
   refreshEventEntries: () => void;
 }
 
-const useEventEntries = (targetDate: Date): UseEventEntriesResult => {
+const useEventEntries = (targetDate?: Date): UseEventEntriesResult => {
   const { userDetails } = useContext(AppContext);
   const [events, setEvents] = React.useState<EventEntry[] | null>(null);
   const [overlappedPlanEvents, setOverlappedPlanEvents] = React.useState<EventEntryTimeCell[]>([]);
@@ -48,7 +48,7 @@ const useEventEntries = (targetDate: Date): UseEventEntriesResult => {
 
   // 初期取得(再取得)
   const refreshEventEntries = React.useCallback(async (): Promise<void> => {
-    if (!userDetails) {
+    if (!userDetails || !targetDate) {
       return;
     }
     try {

--- a/src/shared/data/UserPreference.ts
+++ b/src/shared/data/UserPreference.ts
@@ -16,6 +16,8 @@ export interface UserPreference {
 
   muteWhileInMeeting: boolean;
 
+  startHourLocal: number;
+
   theme?: string;
   openAiKey?: string;
 

--- a/src/shared/data/__tests__/UserPreferenceFixture.ts
+++ b/src/shared/data/__tests__/UserPreferenceFixture.ts
@@ -7,7 +7,7 @@ export class UserPreferenceFixture {
       userId: 'user123',
       syncGoogleCalendar: true,
       calendars: [CalendarSettingFixture.default()],
-      startHourLocal: 6,
+      startHourLocal: 9,
       speakEvent: true,
       speakEventTimeOffset: 15,
       speakEventTextTemplate: 'Event: {event}',

--- a/src/shared/data/__tests__/UserPreferenceFixture.ts
+++ b/src/shared/data/__tests__/UserPreferenceFixture.ts
@@ -7,6 +7,7 @@ export class UserPreferenceFixture {
       userId: 'user123',
       syncGoogleCalendar: true,
       calendars: [CalendarSettingFixture.default()],
+      startHourLocal: 6,
       speakEvent: true,
       speakEventTimeOffset: 15,
       speakEventTextTemplate: 'Event: {event}',


### PR DESCRIPTION
## チケット
#79 

## 実装内容
- 設定画面で1日の開始時間が設定できるよう修正
- タイムラインが設定した開始時間から表示されるよう修正

## 未実装
- 設定した開始時間によってはタイムラインのイベント表示が1日分ずれてしまう
  - 例えば、2/15 18:00 にイベントを作成した後に、1日の開始時間を23時に設定すると、翌日 18:00 のイベントのように表示されてしまう
- テスト 