### PR TITLE
fix: 1日の境界にあるイベントの表示が正しくない

### DIFF
--- a/src/main/services/EventEntryServiceImpl.ts
+++ b/src/main/services/EventEntryServiceImpl.ts
@@ -21,7 +21,11 @@ export class EventEntryServiceImpl implements IEventEntryService {
   async list(userId: string, start: Date, end: Date): Promise<EventEntry[]> {
     const data = await this.dataSource.find(
       this.tableName,
-      { userId: userId, 'start.dateTime': { $gte: start, $lt: end } },
+      {
+        userId: userId,
+        'start.dateTime': { $lt: end },
+        'end.dateTime': { $gte: start },
+      },
       { start: 1 }
     );
     return data;

--- a/src/main/services/EventEntryServiceImpl.ts
+++ b/src/main/services/EventEntryServiceImpl.ts
@@ -1,9 +1,11 @@
+import mainContainer from '@main/inversify.config';
 import { EventEntry } from '@shared/data/EventEntry';
 import { IEventEntryService } from './IEventEntryService';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '@main/types';
 import { DataSource } from './DataSource';
 import { EventEntryFactory } from './EventEntryFactory';
+import { DateUtil } from '@shared/utils/DateUtil';
 
 @injectable()
 export class EventEntryServiceImpl implements IEventEntryService {
@@ -36,7 +38,7 @@ export class EventEntryServiceImpl implements IEventEntryService {
   }
 
   async save(data: EventEntry): Promise<EventEntry> {
-    data.updated = new Date();
+    data.updated = mainContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate();
     EventEntryFactory.validate(data);
     return await this.dataSource.upsert(this.tableName, data);
   }

--- a/src/main/services/WindowLogServiceImpl.ts
+++ b/src/main/services/WindowLogServiceImpl.ts
@@ -20,7 +20,10 @@ export class WindowLogServiceImpl implements IWindowLogService {
   async list(start: Date, end: Date): Promise<WindowLog[]> {
     return await this.dataSource.find(
       this.tableName,
-      { activated: { $gte: start, $lt: end } },
+      {
+        activated: { $lt: end },
+        deactivated: { $gte: start },
+      },
       { activated: 1 }
     );
   }

--- a/src/main/services/WindowLogServiceImpl.ts
+++ b/src/main/services/WindowLogServiceImpl.ts
@@ -1,8 +1,10 @@
+import mainContainer from '@main/inversify.config';
 import { WindowLog } from '@shared/data/WindowLog';
 import { IWindowLogService } from './IWindowLogService';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '@main/types';
 import { DataSource } from './DataSource';
+import { DateUtil } from '@shared/utils/DateUtil';
 
 @injectable()
 export class WindowLogServiceImpl implements IWindowLogService {
@@ -38,7 +40,7 @@ export class WindowLogServiceImpl implements IWindowLogService {
     windowTitle: string,
     path?: string | null
   ): Promise<WindowLog> {
-    const now = new Date();
+    const now = mainContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate();
     return {
       id: this.dataSource.generateUniqueId(),
       basename: basename,

--- a/src/main/services/__tests__/EventEntryServiceImpl.test.ts
+++ b/src/main/services/__tests__/EventEntryServiceImpl.test.ts
@@ -1,0 +1,177 @@
+import { TestDataSource } from './TestDataSource';
+import { EventEntryServiceImpl } from '../EventEntryServiceImpl';
+import { EVENT_TYPE, EventEntry } from '@shared/data/EventEntry';
+import { DataSource } from '../DataSource';
+import { EventDateTimeFixture, EventEntryFixture } from '@shared/data/__tests__/EventEntryFixture';
+import { assert } from 'console';
+
+describe('EventServiceEntryImpl', () => {
+  let service: EventEntryServiceImpl;
+  let dataSource: DataSource<EventEntry>;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    dataSource = new TestDataSource<EventEntry>();
+    service = new EventEntryServiceImpl(dataSource);
+    dataSource.delete(service.tableName, {});
+    const count = await dataSource.count(service.tableName, {});
+    assert(count === 0);
+  });
+
+  describe('list', () => {
+    const start = new Date('2023-07-01T6:00:00+0900');
+    const end = new Date('2023-07-02T6:00:00+0900');
+    const userId = 'user1';
+    const testData = [
+      {
+        description: '取得期間より前にあるイベント',
+        preconditions: [
+          EventEntryFixture.default({
+            id: '1',
+            userId: userId,
+            eventType: EVENT_TYPE.PLAN,
+            start: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-01T3:00:00+0900'),
+            }),
+            end: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-01T5:00:00+0900'),
+            }),
+          }),
+        ],
+        expected: {
+          count: 0,
+          events: [],
+        },
+      },
+      {
+        description: '取得期間の開始日時と重なるイベント',
+        preconditions: [
+          EventEntryFixture.default({
+            id: '1',
+            userId: userId,
+            eventType: EVENT_TYPE.PLAN,
+            start: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-01T5:00:00+0900'),
+            }),
+            end: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-01T7:00:00+0900'),
+            }),
+          }),
+        ],
+        expected: {
+          count: 1,
+          events: [
+            EventEntryFixture.default({
+              id: '1',
+              userId: userId,
+              eventType: EVENT_TYPE.PLAN,
+              start: EventDateTimeFixture.default({
+                dateTime: new Date('2023-07-01T5:00:00+0900'),
+              }),
+              end: EventDateTimeFixture.default({
+                dateTime: new Date('2023-07-01T7:00:00+0900'),
+              }),
+            }),
+          ],
+        },
+      },
+      {
+        description: '取得期間内に収まっているイベント',
+        preconditions: [
+          EventEntryFixture.default({
+            id: '1',
+            userId: userId,
+            eventType: EVENT_TYPE.PLAN,
+            start: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-01T10:00:00+0900'),
+            }),
+            end: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-01T12:00:00+0900'),
+            }),
+          }),
+        ],
+        expected: {
+          count: 1,
+          events: [
+            EventEntryFixture.default({
+              id: '1',
+              userId: userId,
+              eventType: EVENT_TYPE.PLAN,
+              start: EventDateTimeFixture.default({
+                dateTime: new Date('2023-07-01T10:00:00+0900'),
+              }),
+              end: EventDateTimeFixture.default({
+                dateTime: new Date('2023-07-01T12:00:00+0900'),
+              }),
+            }),
+          ],
+        },
+      },
+      {
+        description: '取得期間の終了日時と重なるイベント',
+        preconditions: [
+          EventEntryFixture.default({
+            id: '1',
+            userId: userId,
+            eventType: EVENT_TYPE.PLAN,
+            start: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-02T5:00:00+0900'),
+            }),
+            end: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-02T7:00:00+0900'),
+            }),
+          }),
+        ],
+        expected: {
+          count: 1,
+          events: [
+            EventEntryFixture.default({
+              id: '1',
+              userId: userId,
+              eventType: EVENT_TYPE.PLAN,
+              start: EventDateTimeFixture.default({
+                dateTime: new Date('2023-07-02T5:00:00+0900'),
+              }),
+              end: EventDateTimeFixture.default({
+                dateTime: new Date('2023-07-02T7:00:00+0900'),
+              }),
+            }),
+          ],
+        },
+      },
+      {
+        description: '取得期間より後のイベント',
+        preconditions: [
+          EventEntryFixture.default({
+            id: '1',
+            userId: userId,
+            eventType: EVENT_TYPE.PLAN,
+            start: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-02T10:00:00+0900'),
+            }),
+            end: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-02T12:00:00+0900'),
+            }),
+          }),
+        ],
+        expected: {
+          count: 0,
+          events: [],
+        },
+      },
+    ];
+    it.each(testData)('%s', async (testData) => {
+      for (const precondiction of testData.preconditions) {
+        await service.save(precondiction);
+      }
+      const count = await dataSource.count(service.tableName, {});
+      console.log('db.count', count);
+      const events = await service.list(userId, start, end);
+      const expected = testData.expected;
+      expect(events).toHaveLength(expected.count);
+      for (let i = 0; i < events.length; i++) {
+        expect(events[i]).toContain(expected.events[i]);
+      }
+    });
+  });
+});

--- a/src/main/services/__tests__/EventEntryServiceImpl.test.ts
+++ b/src/main/services/__tests__/EventEntryServiceImpl.test.ts
@@ -1,16 +1,21 @@
+import mainContainer from '@main/inversify.config';
 import { TestDataSource } from './TestDataSource';
 import { EventEntryServiceImpl } from '../EventEntryServiceImpl';
 import { EVENT_TYPE, EventEntry } from '@shared/data/EventEntry';
 import { DataSource } from '../DataSource';
 import { EventDateTimeFixture, EventEntryFixture } from '@shared/data/__tests__/EventEntryFixture';
 import { assert } from 'console';
+import { DateUtil } from '@shared/utils/DateUtil';
+import { TYPES } from '@main/types';
 
 describe('EventServiceEntryImpl', () => {
   let service: EventEntryServiceImpl;
   let dataSource: DataSource<EventEntry>;
+  let dateUtil: DateUtil;
 
   beforeEach(async () => {
     jest.resetAllMocks();
+    dateUtil = mainContainer.get<DateUtil>(TYPES.DateUtil);
     dataSource = new TestDataSource<EventEntry>();
     service = new EventEntryServiceImpl(dataSource);
     dataSource.delete(service.tableName, {});
@@ -19,8 +24,9 @@ describe('EventServiceEntryImpl', () => {
   });
 
   describe('list', () => {
-    const start = new Date('2023-07-01T6:00:00+0900');
-    const end = new Date('2023-07-02T6:00:00+0900');
+    const NOW_TIME = new Date('2023-07-03T10:00:00+0900');
+    const start = new Date('2023-07-01T06:00:00+0900');
+    const end = new Date('2023-07-02T06:00:00+0900');
     const userId = 'user1';
     const testData = [
       {
@@ -30,11 +36,12 @@ describe('EventServiceEntryImpl', () => {
             id: '1',
             userId: userId,
             eventType: EVENT_TYPE.PLAN,
+            summary: 'test event',
             start: EventDateTimeFixture.default({
-              dateTime: new Date('2023-07-01T3:00:00+0900'),
+              dateTime: new Date('2023-07-01T03:00:00+0900'),
             }),
             end: EventDateTimeFixture.default({
-              dateTime: new Date('2023-07-01T5:00:00+0900'),
+              dateTime: new Date('2023-07-01T05:00:00+0900'),
             }),
           }),
         ],
@@ -50,11 +57,12 @@ describe('EventServiceEntryImpl', () => {
             id: '1',
             userId: userId,
             eventType: EVENT_TYPE.PLAN,
+            summary: 'test event',
             start: EventDateTimeFixture.default({
-              dateTime: new Date('2023-07-01T5:00:00+0900'),
+              dateTime: new Date('2023-07-01T05:00:00+0900'),
             }),
             end: EventDateTimeFixture.default({
-              dateTime: new Date('2023-07-01T7:00:00+0900'),
+              dateTime: new Date('2023-07-01T07:00:00+0900'),
             }),
           }),
         ],
@@ -65,12 +73,14 @@ describe('EventServiceEntryImpl', () => {
               id: '1',
               userId: userId,
               eventType: EVENT_TYPE.PLAN,
+              summary: 'test event',
               start: EventDateTimeFixture.default({
-                dateTime: new Date('2023-07-01T5:00:00+0900'),
+                dateTime: new Date('2023-07-01T05:00:00+0900'),
               }),
               end: EventDateTimeFixture.default({
-                dateTime: new Date('2023-07-01T7:00:00+0900'),
+                dateTime: new Date('2023-07-01T07:00:00+0900'),
               }),
+              updated: NOW_TIME,
             }),
           ],
         },
@@ -82,6 +92,7 @@ describe('EventServiceEntryImpl', () => {
             id: '1',
             userId: userId,
             eventType: EVENT_TYPE.PLAN,
+            summary: 'test event',
             start: EventDateTimeFixture.default({
               dateTime: new Date('2023-07-01T10:00:00+0900'),
             }),
@@ -97,12 +108,14 @@ describe('EventServiceEntryImpl', () => {
               id: '1',
               userId: userId,
               eventType: EVENT_TYPE.PLAN,
+              summary: 'test event',
               start: EventDateTimeFixture.default({
                 dateTime: new Date('2023-07-01T10:00:00+0900'),
               }),
               end: EventDateTimeFixture.default({
                 dateTime: new Date('2023-07-01T12:00:00+0900'),
               }),
+              updated: NOW_TIME,
             }),
           ],
         },
@@ -114,11 +127,12 @@ describe('EventServiceEntryImpl', () => {
             id: '1',
             userId: userId,
             eventType: EVENT_TYPE.PLAN,
+            summary: 'test event',
             start: EventDateTimeFixture.default({
-              dateTime: new Date('2023-07-02T5:00:00+0900'),
+              dateTime: new Date('2023-07-02T05:00:00+0900'),
             }),
             end: EventDateTimeFixture.default({
-              dateTime: new Date('2023-07-02T7:00:00+0900'),
+              dateTime: new Date('2023-07-02T07:00:00+0900'),
             }),
           }),
         ],
@@ -129,12 +143,14 @@ describe('EventServiceEntryImpl', () => {
               id: '1',
               userId: userId,
               eventType: EVENT_TYPE.PLAN,
+              summary: 'test event',
               start: EventDateTimeFixture.default({
-                dateTime: new Date('2023-07-02T5:00:00+0900'),
+                dateTime: new Date('2023-07-02T05:00:00+0900'),
               }),
               end: EventDateTimeFixture.default({
-                dateTime: new Date('2023-07-02T7:00:00+0900'),
+                dateTime: new Date('2023-07-02T07:00:00+0900'),
               }),
+              updated: NOW_TIME,
             }),
           ],
         },
@@ -146,6 +162,7 @@ describe('EventServiceEntryImpl', () => {
             id: '1',
             userId: userId,
             eventType: EVENT_TYPE.PLAN,
+            summary: 'test event',
             start: EventDateTimeFixture.default({
               dateTime: new Date('2023-07-02T10:00:00+0900'),
             }),
@@ -159,18 +176,138 @@ describe('EventServiceEntryImpl', () => {
           events: [],
         },
       },
+      {
+        description: 'イベントが複数ある場合',
+        preconditions: [
+          EventEntryFixture.default({
+            id: '1',
+            userId: userId,
+            eventType: EVENT_TYPE.PLAN,
+            summary: 'test event 1',
+            start: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-02T10:00:00+0900'),
+            }),
+            end: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-02T12:00:00+0900'),
+            }),
+          }),
+          EventEntryFixture.default({
+            id: '2',
+            userId: userId,
+            eventType: EVENT_TYPE.PLAN,
+            summary: 'test event 2',
+            start: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-02T05:00:00+0900'),
+            }),
+            end: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-02T07:00:00+0900'),
+            }),
+          }),
+          EventEntryFixture.default({
+            id: '3',
+            userId: userId,
+            eventType: EVENT_TYPE.PLAN,
+            summary: 'test event 3',
+            start: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-01T10:00:00+0900'),
+            }),
+            end: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-01T12:00:00+0900'),
+            }),
+          }),
+          EventEntryFixture.default({
+            id: '4',
+            userId: userId,
+            eventType: EVENT_TYPE.PLAN,
+            summary: 'test event 4',
+            start: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-01T05:00:00+0900'),
+            }),
+            end: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-01T07:00:00+0900'),
+            }),
+          }),
+          EventEntryFixture.default({
+            id: '5',
+            userId: userId,
+            eventType: EVENT_TYPE.PLAN,
+            summary: 'test event 5',
+            start: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-01T03:00:00+0900'),
+            }),
+            end: EventDateTimeFixture.default({
+              dateTime: new Date('2023-07-01T05:00:00+0900'),
+            }),
+          }),
+        ],
+        expected: {
+          count: 3,
+          events: [
+            EventEntryFixture.default({
+              id: '4',
+              userId: userId,
+              eventType: EVENT_TYPE.PLAN,
+              summary: 'test event 4',
+              start: EventDateTimeFixture.default({
+                dateTime: new Date('2023-07-01T05:00:00+0900'),
+              }),
+              end: EventDateTimeFixture.default({
+                dateTime: new Date('2023-07-01T07:00:00+0900'),
+              }),
+              updated: NOW_TIME,
+            }),
+            EventEntryFixture.default({
+              id: '3',
+              userId: userId,
+              eventType: EVENT_TYPE.PLAN,
+              summary: 'test event 3',
+              start: EventDateTimeFixture.default({
+                dateTime: new Date('2023-07-01T10:00:00+0900'),
+              }),
+              end: EventDateTimeFixture.default({
+                dateTime: new Date('2023-07-01T12:00:00+0900'),
+              }),
+              updated: NOW_TIME,
+            }),
+            EventEntryFixture.default({
+              id: '2',
+              userId: userId,
+              eventType: EVENT_TYPE.PLAN,
+              summary: 'test event 2',
+              start: EventDateTimeFixture.default({
+                dateTime: new Date('2023-07-02T05:00:00+0900'),
+              }),
+              end: EventDateTimeFixture.default({
+                dateTime: new Date('2023-07-02T07:00:00+0900'),
+              }),
+              updated: NOW_TIME,
+            }),
+          ],
+        },
+      },
     ];
     it.each(testData)('%s', async (testData) => {
+      jest.spyOn(dateUtil, 'getCurrentDate').mockReturnValue(NOW_TIME);
       for (const precondiction of testData.preconditions) {
         await service.save(precondiction);
       }
-      const count = await dataSource.count(service.tableName, {});
-      console.log('db.count', count);
       const events = await service.list(userId, start, end);
       const expected = testData.expected;
       expect(events).toHaveLength(expected.count);
       for (let i = 0; i < events.length; i++) {
-        expect(events[i]).toContain(expected.events[i]);
+        expect(events[i].id).toEqual(expected.events[i].id);
+        expect(events[i].userId).toEqual(expected.events[i].userId);
+        expect(events[i].eventType).toEqual(expected.events[i].eventType);
+        expect(events[i].summary).toEqual(expected.events[i].summary);
+        expect(events[i].start.date).toEqual(expected.events[i].start.date);
+        expect(events[i].start.dateTime).toEqual(expected.events[i].start.dateTime);
+        expect(events[i].end.date).toEqual(expected.events[i].end.date);
+        expect(events[i].end.dateTime).toEqual(expected.events[i].end.dateTime);
+        expect(events[i].location).toEqual(expected.events[i].location);
+        expect(events[i].description).toEqual(expected.events[i].description);
+        expect(events[i].lastSynced).toEqual(expected.events[i].lastSynced);
+        expect(events[i].updated).toEqual(expected.events[i].updated);
+        expect(events[i].deleted).toEqual(expected.events[i].deleted);
       }
     });
   });

--- a/src/main/services/__tests__/WindowLogServiceImpl.test.ts
+++ b/src/main/services/__tests__/WindowLogServiceImpl.test.ts
@@ -1,0 +1,214 @@
+import { TestDataSource } from './TestDataSource';
+import { DataSource } from '../DataSource';
+import { WindowLogFixture } from '@shared/data/__tests__/WindowLogFixture';
+import { assert } from 'console';
+import { WindowLogServiceImpl } from '../WindowLogServiceImpl';
+import { WindowLog } from '@shared/data/WindowLog';
+
+describe('WindowLogServiceEntryImpl', () => {
+  let service: WindowLogServiceImpl;
+  let dataSource: DataSource<WindowLog>;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    dataSource = new TestDataSource<WindowLog>();
+    service = new WindowLogServiceImpl(dataSource);
+    dataSource.delete(service.tableName, {});
+    const count = await dataSource.count(service.tableName, {});
+    assert(count === 0);
+  });
+
+  describe('list', () => {
+    const start = new Date('2023-07-01T06:00:00+0900');
+    const end = new Date('2023-07-02T06:00:00+0900');
+    const testData = [
+      {
+        description: '取得期間より前に非アクティブになったウィンドウ',
+        preconditions: [
+          WindowLogFixture.default({
+            id: '1',
+            basename: 'test.exe',
+            windowTitle: 'test title',
+            activated: new Date('2023-07-01T03:00:00+0900'),
+            deactivated: new Date('2023-07-01T05:00:00+0900'),
+          }),
+        ],
+        expected: {
+          count: 0,
+          winlogs: [],
+        },
+      },
+      {
+        description: '取得期間の開始日時のタイミングでアクティブだったウィンドウ',
+        preconditions: [
+          WindowLogFixture.default({
+            id: '1',
+            basename: 'test.exe',
+            windowTitle: 'test title',
+            activated: new Date('2023-07-01T05:00:00+0900'),
+            deactivated: new Date('2023-07-01T07:00:00+0900'),
+          }),
+        ],
+        expected: {
+          count: 1,
+          winlogs: [
+            WindowLogFixture.default({
+              id: '1',
+              basename: 'test.exe',
+              windowTitle: 'test title',
+              activated: new Date('2023-07-01T05:00:00+0900'),
+              deactivated: new Date('2023-07-01T07:00:00+0900'),
+            }),
+          ],
+        },
+      },
+      {
+        description: 'アクティブだった期間が取得期間内に収まっているウィンドウ',
+        preconditions: [
+          WindowLogFixture.default({
+            id: '1',
+            basename: 'test.exe',
+            windowTitle: 'test title',
+            activated: new Date('2023-07-01T10:00:00+0900'),
+            deactivated: new Date('2023-07-01T12:00:00+0900'),
+          }),
+        ],
+        expected: {
+          count: 1,
+          winlogs: [
+            WindowLogFixture.default({
+              id: '1',
+              basename: 'test.exe',
+              windowTitle: 'test title',
+              activated: new Date('2023-07-01T10:00:00+0900'),
+              deactivated: new Date('2023-07-01T12:00:00+0900'),
+            }),
+          ],
+        },
+      },
+      {
+        description: '取得期間の終了日時にアクティブだったイベント',
+        preconditions: [
+          WindowLogFixture.default({
+            id: '1',
+            basename: 'test.exe',
+            windowTitle: 'test title',
+            activated: new Date('2023-07-02T05:00:00+0900'),
+            deactivated: new Date('2023-07-02T07:00:00+0900'),
+          }),
+        ],
+        expected: {
+          count: 1,
+          winlogs: [
+            WindowLogFixture.default({
+              id: '1',
+              basename: 'test.exe',
+              windowTitle: 'test title',
+              activated: new Date('2023-07-02T05:00:00+0900'),
+              deactivated: new Date('2023-07-02T07:00:00+0900'),
+            }),
+          ],
+        },
+      },
+      {
+        description: '取得期間後にアクティブになったウィンドウ',
+        preconditions: [
+          WindowLogFixture.default({
+            id: '1',
+            basename: 'test.exe',
+            windowTitle: 'test title',
+            activated: new Date('2023-07-02T10:00:00+0900'),
+            deactivated: new Date('2023-07-02T12:00:00+0900'),
+          }),
+        ],
+        expected: {
+          count: 0,
+          winlogs: [],
+        },
+      },
+      {
+        description: 'ウィンドウが複数ある場合',
+        preconditions: [
+          WindowLogFixture.default({
+            id: '1',
+            basename: 'test1.exe',
+            windowTitle: 'test title 1',
+            activated: new Date('2023-07-02T10:00:00+0900'),
+            deactivated: new Date('2023-07-02T12:00:00+0900'),
+          }),
+          WindowLogFixture.default({
+            id: '2',
+            basename: 'test2.exe',
+            windowTitle: 'test title 2',
+            activated: new Date('2023-07-02T05:00:00+0900'),
+            deactivated: new Date('2023-07-02T07:00:00+0900'),
+          }),
+          WindowLogFixture.default({
+            id: '3',
+            basename: 'test3.exe',
+            windowTitle: 'test title 3',
+            activated: new Date('2023-07-01T10:00:00+0900'),
+            deactivated: new Date('2023-07-01T12:00:00+0900'),
+          }),
+          WindowLogFixture.default({
+            id: '4',
+            basename: 'test4.exe',
+            windowTitle: 'test title 4',
+            activated: new Date('2023-07-01T05:00:00+0900'),
+            deactivated: new Date('2023-07-01T07:00:00+0900'),
+          }),
+          WindowLogFixture.default({
+            id: '5',
+            basename: 'test5.exe',
+            windowTitle: 'test title 5',
+            activated: new Date('2023-07-01T03:00:00+0900'),
+            deactivated: new Date('2023-07-01T05:00:00+0900'),
+          }),
+        ],
+        expected: {
+          count: 3,
+          winlogs: [
+            WindowLogFixture.default({
+              id: '4',
+              basename: 'test4.exe',
+              windowTitle: 'test title 4',
+              activated: new Date('2023-07-01T05:00:00+0900'),
+              deactivated: new Date('2023-07-01T07:00:00+0900'),
+            }),
+            WindowLogFixture.default({
+              id: '3',
+              basename: 'test3.exe',
+              windowTitle: 'test title 3',
+              activated: new Date('2023-07-01T10:00:00+0900'),
+              deactivated: new Date('2023-07-01T12:00:00+0900'),
+            }),
+            WindowLogFixture.default({
+              id: '2',
+              basename: 'test2.exe',
+              windowTitle: 'test title 2',
+              activated: new Date('2023-07-02T05:00:00+0900'),
+              deactivated: new Date('2023-07-02T07:00:00+0900'),
+            }),
+          ],
+        },
+      },
+    ];
+    it.each(testData)('%s', async (testData) => {
+      for (const precondiction of testData.preconditions) {
+        await service.save(precondiction);
+      }
+      const winlogs = await service.list(start, end);
+      const expected = testData.expected;
+      expect(winlogs).toHaveLength(expected.count);
+      for (let i = 0; i < winlogs.length; i++) {
+        expect(winlogs[i].id).toEqual(expected.winlogs[i].id);
+        expect(winlogs[i].basename).toEqual(expected.winlogs[i].basename);
+        expect(winlogs[i].pid).toEqual(expected.winlogs[i].pid);
+        expect(winlogs[i].windowTitle).toEqual(expected.winlogs[i].windowTitle);
+        expect(winlogs[i].path).toEqual(expected.winlogs[i].path);
+        expect(winlogs[i].activated).toEqual(expected.winlogs[i].activated);
+        expect(winlogs[i].deactivated).toEqual(expected.winlogs[i].deactivated);
+      }
+    });
+  });
+});

--- a/src/renderer/src/components/timeTable/ActivityTableLane.tsx
+++ b/src/renderer/src/components/timeTable/ActivityTableLane.tsx
@@ -1,7 +1,7 @@
 import { TimeCell } from './common';
 import { ActivitySlot } from './ActivitySlot';
 import { EventTimeCell } from '@renderer/services/EventTimeCell';
-import { TimeLeneContainer } from './TimeLane';
+import { TimeLaneContainer } from './TimeLane';
 import { ActivitySlotText } from './ActivitySlotText';
 
 interface ActivityTableLaneProps {
@@ -14,7 +14,7 @@ interface ActivityTableLaneProps {
  */
 export const ActivityTableLane = ({ overlappedEvents }: ActivityTableLaneProps): JSX.Element => {
   return (
-    <TimeLeneContainer name={'activity'}>
+    <TimeLaneContainer name={'activity'}>
       {overlappedEvents.map((oe) => (
         <ActivitySlot key={oe.id} eventTimeCell={oe}>
           <ActivitySlotText eventTimeCell={oe} />
@@ -23,6 +23,6 @@ export const ActivityTableLane = ({ overlappedEvents }: ActivityTableLaneProps):
       {Array.from({ length: 24 }).map((_, i, self) => (
         <TimeCell key={i} isBottom={i === self.length - 1} isRight={true} />
       ))}
-    </TimeLeneContainer>
+    </TimeLaneContainer>
   );
 };

--- a/src/renderer/src/components/timeTable/TimeLane.tsx
+++ b/src/renderer/src/components/timeTable/TimeLane.tsx
@@ -31,7 +31,7 @@ export const TimeLane = ({
   onResizeStop,
 }: TimeLaneProps): JSX.Element => {
   return (
-    <TimeLeneContainer name={name}>
+    <TimeLaneContainer name={name}>
       {overlappedEvents.map((oe) => (
         <EventSlot
           key={oe.id}
@@ -54,16 +54,16 @@ export const TimeLane = ({
           }}
         />
       ))}
-    </TimeLeneContainer>
+    </TimeLaneContainer>
   );
 };
 
-interface TimeLeneContainerProps {
+interface TimeLaneContainerProps {
   name: string;
   children: React.ReactNode;
 }
 
-export const TimeLeneContainer = ({ name, children }: TimeLeneContainerProps): JSX.Element => {
+export const TimeLaneContainer = ({ name, children }: TimeLaneContainerProps): JSX.Element => {
   const containerRef = useRef<HTMLDivElement>(null);
   // if (containerRef.current) {
   //   console.log(containerRef.current.className);

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -8,7 +8,7 @@ import { useContext, useEffect, useState } from 'react';
 import EventEntryForm, { FORM_MODE } from './EventEntryForm';
 import { useEventEntries } from '@renderer/hooks/useEventEntries';
 import { DatePicker } from '@mui/x-date-pickers';
-import { startHourLocal, HeaderCell, TimeCell } from './common';
+import { startHourLocal, HeaderCell, TimeCell, getStartDate } from './common';
 import { useActivityEvents } from '@renderer/hooks/useActivityEvents';
 import { TimeLane, TimeLeneContainer } from './TimeLane';
 import { DragDropResizeState } from './EventSlot';
@@ -21,6 +21,7 @@ import { useGitHubAuth } from '@renderer/hooks/useGitHubAuth';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import { IpcChannel } from '@shared/constants';
 import { ActivityTableLane } from './ActivityTableLane';
+import { DateUtil } from '@shared/utils/DateUtil';
 
 /**
  * TimeTable は、タイムラインを表示する
@@ -28,7 +29,9 @@ import { ActivityTableLane } from './ActivityTableLane';
  */
 const TimeTable = (): JSX.Element => {
   console.log('TimeTable');
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const now = rendererContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate();
+  // 日付は1日の開始時刻で保存する
+  const [selectedDate, setSelectedDate] = useState(getStartDate(now));
   const {
     events: eventEntries,
     overlappedPlanEvents,
@@ -122,7 +125,8 @@ const TimeTable = (): JSX.Element => {
   };
 
   const handleToday = (): void => {
-    setSelectedDate(new Date());
+    const now = rendererContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate();
+    setSelectedDate(getStartDate(now));
   };
 
   const handlePrevDay = (): void => {

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -8,9 +8,9 @@ import { useContext, useEffect, useState } from 'react';
 import EventEntryForm, { FORM_MODE } from './EventEntryForm';
 import { useEventEntries } from '@renderer/hooks/useEventEntries';
 import { DatePicker } from '@mui/x-date-pickers';
-import { startHourLocal, HeaderCell, TimeCell, getStartDate } from './common';
+import { startHourLocal, HeaderCell, TimeCell, getStartDate, SelectedDateContext } from './common';
 import { useActivityEvents } from '@renderer/hooks/useActivityEvents';
-import { TimeLane, TimeLeneContainer } from './TimeLane';
+import { TimeLane, TimeLaneContainer } from './TimeLane';
 import { DragDropResizeState } from './EventSlot';
 import { eventDateTimeToDate } from '@shared/data/EventDateTime';
 import SyncIcon from '@mui/icons-material/Sync';
@@ -215,117 +215,119 @@ const TimeTable = (): JSX.Element => {
 
   return (
     <>
-      <Grid container spacing={1} sx={{ marginBottom: '0.5rem' }} alignItems="center">
-        <Grid item sx={{ marginRight: '0.5rem' }}>
-          <Button variant="outlined" onClick={handleToday}>
-            今日
-          </Button>
-        </Grid>
-        <Grid item sx={{ marginRight: '0.5rem' }}>
-          <Button variant="outlined" onClick={handlePrevDay}>
-            &lt;
-          </Button>
-        </Grid>
-        <Grid item sx={{ marginRight: '0.5rem' }}>
-          <Button variant="outlined" onClick={handleNextDay}>
-            &gt;
-          </Button>
-        </Grid>
-        <Grid item sx={{ marginRight: '0.5rem' }}>
-          <DatePicker
-            sx={{ width: '10rem' }}
-            value={selectedDate}
-            format={'yyyy/MM/dd'}
-            slotProps={{ textField: { size: 'small' } }}
-            onChange={handleDateChange}
-          />
-        </Grid>
-        <Grid item sx={{ marginRight: '0.5rem' }}>
-          {showCalendarSyncButton && (
-            <Button variant="outlined" onClick={handleSyncCalendar} disabled={isCalendarSyncing}>
-              <SyncIcon />
-              カレンダーと同期
+      <SelectedDateContext.Provider value={selectedDate}>
+        <Grid container spacing={1} sx={{ marginBottom: '0.5rem' }} alignItems="center">
+          <Grid item sx={{ marginRight: '0.5rem' }}>
+            <Button variant="outlined" onClick={handleToday}>
+              今日
             </Button>
-          )}
-        </Grid>
-        <Grid item sx={{ marginRight: '0.5rem' }}>
-          {isGitHubAuthenticated && (
-            <Button variant="outlined" onClick={handleSyncGitHub} disabled={isGitHubSyncing}>
-              <GitHubIcon sx={{ marginRight: '0.25rem' }} />
-              GitHubイベント
+          </Grid>
+          <Grid item sx={{ marginRight: '0.5rem' }}>
+            <Button variant="outlined" onClick={handlePrevDay}>
+              &lt;
             </Button>
-          )}
-        </Grid>
-      </Grid>
-
-      <Grid container spacing={0}>
-        <Grid item xs={1}>
-          <HeaderCell></HeaderCell>
-          <TimeLeneContainer name={'axis'}>
-            {Array.from({ length: 24 }).map((_, hour, self) => (
-              <TimeCell key={hour} isBottom={hour === self.length - 1}>
-                {(hour + startHourLocal) % 24}
-              </TimeCell>
-            ))}
-          </TimeLeneContainer>
-        </Grid>
-        <Grid item xs={4}>
-          <HeaderCell>予定</HeaderCell>
-          {overlappedPlanEvents && (
-            <TimeLane
-              name="plan"
-              backgroundColor={theme.palette.primary.main}
-              overlappedEvents={overlappedPlanEvents}
-              onAddEventEntry={(hour: number): void => {
-                handleOpenEventEntryForm(FORM_MODE.NEW, EVENT_TYPE.PLAN, hour);
-              }}
-              onUpdateEventEntry={(eventEntry: EventEntry): void => {
-                // TODO EventDateTime の対応
-                const hour = eventDateTimeToDate(eventEntry.start).getHours();
-                handleOpenEventEntryForm(FORM_MODE.EDIT, EVENT_TYPE.PLAN, hour, eventEntry);
-              }}
-              onDragStop={handleDragStop}
-              onResizeStop={handleResizeStop}
+          </Grid>
+          <Grid item sx={{ marginRight: '0.5rem' }}>
+            <Button variant="outlined" onClick={handleNextDay}>
+              &gt;
+            </Button>
+          </Grid>
+          <Grid item sx={{ marginRight: '0.5rem' }}>
+            <DatePicker
+              sx={{ width: '10rem' }}
+              value={selectedDate}
+              format={'yyyy/MM/dd'}
+              slotProps={{ textField: { size: 'small' } }}
+              onChange={handleDateChange}
             />
-          )}
+          </Grid>
+          <Grid item sx={{ marginRight: '0.5rem' }}>
+            {showCalendarSyncButton && (
+              <Button variant="outlined" onClick={handleSyncCalendar} disabled={isCalendarSyncing}>
+                <SyncIcon />
+                カレンダーと同期
+              </Button>
+            )}
+          </Grid>
+          <Grid item sx={{ marginRight: '0.5rem' }}>
+            {isGitHubAuthenticated && (
+              <Button variant="outlined" onClick={handleSyncGitHub} disabled={isGitHubSyncing}>
+                <GitHubIcon sx={{ marginRight: '0.25rem' }} />
+                GitHubイベント
+              </Button>
+            )}
+          </Grid>
         </Grid>
-        <Grid item xs={4}>
-          <HeaderCell>実績</HeaderCell>
-          {overlappedActualEvents && (
-            <TimeLane
-              name="actual"
-              backgroundColor={theme.palette.secondary.main}
-              overlappedEvents={overlappedActualEvents}
-              onAddEventEntry={(hour: number): void => {
-                handleOpenEventEntryForm(FORM_MODE.NEW, EVENT_TYPE.ACTUAL, hour);
-              }}
-              onUpdateEventEntry={(eventEntry: EventEntry): void => {
-                // TODO EventDateTime の対応
-                const hour = eventDateTimeToDate(eventEntry.start).getHours();
-                handleOpenEventEntryForm(FORM_MODE.EDIT, EVENT_TYPE.ACTUAL, hour, eventEntry);
-              }}
-              onDragStop={handleDragStop}
-              onResizeStop={handleResizeStop}
-            />
-          )}
-        </Grid>
-        <Grid item xs={3}>
-          <HeaderCell isRight={true}>アクティビティ</HeaderCell>
-          <ActivityTableLane overlappedEvents={overlappedActivityEvents} />
-        </Grid>
-      </Grid>
 
-      <EventEntryForm
-        isOpen={isOpenEventEntryForm}
-        mode={selectedFormMode}
-        eventType={selectedEventType}
-        targetDate={selectedDate}
-        startHour={selectedHour}
-        eventEntry={selectedEvent}
-        onSubmit={handleSaveEventEntry}
-        onClose={handleCloseEventEntryForm}
-        onDelete={handleDeleteEventEntry}
-      />
+        <Grid container spacing={0}>
+          <Grid item xs={1}>
+            <HeaderCell></HeaderCell>
+            <TimeLaneContainer name={'axis'}>
+              {Array.from({ length: 24 }).map((_, hour, self) => (
+                <TimeCell key={hour} isBottom={hour === self.length - 1}>
+                  {(hour + startHourLocal) % 24}
+                </TimeCell>
+              ))}
+            </TimeLaneContainer>
+          </Grid>
+          <Grid item xs={4}>
+            <HeaderCell>予定</HeaderCell>
+            {overlappedPlanEvents && (
+              <TimeLane
+                name="plan"
+                backgroundColor={theme.palette.primary.main}
+                overlappedEvents={overlappedPlanEvents}
+                onAddEventEntry={(hour: number): void => {
+                  handleOpenEventEntryForm(FORM_MODE.NEW, EVENT_TYPE.PLAN, hour);
+                }}
+                onUpdateEventEntry={(eventEntry: EventEntry): void => {
+                  // TODO EventDateTime の対応
+                  const hour = eventDateTimeToDate(eventEntry.start).getHours();
+                  handleOpenEventEntryForm(FORM_MODE.EDIT, EVENT_TYPE.PLAN, hour, eventEntry);
+                }}
+                onDragStop={handleDragStop}
+                onResizeStop={handleResizeStop}
+              />
+            )}
+          </Grid>
+          <Grid item xs={4}>
+            <HeaderCell>実績</HeaderCell>
+            {overlappedActualEvents && (
+              <TimeLane
+                name="actual"
+                backgroundColor={theme.palette.secondary.main}
+                overlappedEvents={overlappedActualEvents}
+                onAddEventEntry={(hour: number): void => {
+                  handleOpenEventEntryForm(FORM_MODE.NEW, EVENT_TYPE.ACTUAL, hour);
+                }}
+                onUpdateEventEntry={(eventEntry: EventEntry): void => {
+                  // TODO EventDateTime の対応
+                  const hour = eventDateTimeToDate(eventEntry.start).getHours();
+                  handleOpenEventEntryForm(FORM_MODE.EDIT, EVENT_TYPE.ACTUAL, hour, eventEntry);
+                }}
+                onDragStop={handleDragStop}
+                onResizeStop={handleResizeStop}
+              />
+            )}
+          </Grid>
+          <Grid item xs={3}>
+            <HeaderCell isRight={true}>アクティビティ</HeaderCell>
+            <ActivityTableLane overlappedEvents={overlappedActivityEvents} />
+          </Grid>
+        </Grid>
+
+        <EventEntryForm
+          isOpen={isOpenEventEntryForm}
+          mode={selectedFormMode}
+          eventType={selectedEventType}
+          targetDate={selectedDate}
+          startHour={selectedHour}
+          eventEntry={selectedEvent}
+          onSubmit={handleSaveEventEntry}
+          onClose={handleCloseEventEntryForm}
+          onDelete={handleDeleteEventEntry}
+        />
+      </SelectedDateContext.Provider>
     </>
   );
 };

--- a/src/renderer/src/components/timeTable/common.ts
+++ b/src/renderer/src/components/timeTable/common.ts
@@ -32,6 +32,7 @@ export const HeaderCell = styled(Cell)(({ theme }) => ({
 }));
 
 export const ParentRefContext = React.createContext<React.RefObject<HTMLDivElement> | null>(null);
+export const SelectedDateContext = React.createContext<Date>(new Date());
 
 /**
  * 指定された日時における1日の開始日時を取得します。

--- a/src/renderer/src/components/timeTable/common.ts
+++ b/src/renderer/src/components/timeTable/common.ts
@@ -1,6 +1,6 @@
 import { styled } from '@mui/system';
 import { Box } from '@mui/material';
-import { differenceInMinutes, startOfDay } from 'date-fns';
+import { addDays, differenceInMinutes, startOfDay } from 'date-fns';
 import React from 'react';
 
 // TODO 設定画面で設定できるようにする
@@ -32,6 +32,27 @@ export const HeaderCell = styled(Cell)(({ theme }) => ({
 }));
 
 export const ParentRefContext = React.createContext<React.RefObject<HTMLDivElement> | null>(null);
+
+/**
+ * 指定された日時における1日の開始日時を取得します。
+ *
+ * startHourLocal が 6:00 のとき、 date に 2/15 10:00 を指定すると 2/15 6:00 を返す。
+ * startHourLocal が 6:00 のとき、 date に 2/15 5:00 を指定すると 2/14 6:00 を返す。
+ *
+ * @param date
+ * @returns
+ */
+
+export const getStartDate = (date: Date): Date => {
+  let startDate = new Date(date);
+  // 1日の開始時刻に設定する
+  startDate.setHours(startHourLocal, 0, 0, 0);
+  if (date < startDate) {
+    // 現在時刻が1日の開始時刻より前の場合、日付を1日前にする
+    startDate = addDays(startDate, -1);
+  }
+  return startDate;
+};
 
 /**
  * 指定の時間をテーブルのオフセット値（時間単位）に変換します。

--- a/src/renderer/src/inversify.config.ts
+++ b/src/renderer/src/inversify.config.ts
@@ -29,6 +29,7 @@ import { ILabelProxy } from './services/ILabelProxy';
 import { LabelProxyImpl } from './services/LabelProxyImpl';
 import { IProjectProxy } from './services/IProjectProxy';
 import { ProjectProxyImpl } from './services/ProjectProxyImpl';
+import { DateUtil } from '@shared/utils/DateUtil';
 
 // コンテナの作成
 const container = new Container();
@@ -76,5 +77,8 @@ container
   .bind<IOverlapEventService>(TYPES.OverlapEventService)
   .to(OverlapEventServiceImpl)
   .inSingletonScope();
+
+// ユーティリティ
+container.bind(TYPES.DateUtil).to(DateUtil).inSingletonScope();
 
 export default container;

--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -20,4 +20,7 @@ export const TYPES = {
   // service
   SpeakEventSubscriber: Symbol.for('SpeakEventService'),
   OverlapEventService: Symbol.for('OverlapEventService'),
+
+  // shared/utils
+  DateUtil: Symbol.for('DateUtil'),
 };


### PR DESCRIPTION
## チケット
#66

## 実装内容
- タイムテーブルの日付の初期値を1日の開始時刻にする
- タイムテーブルの日付をDIコンテナから取得
- イベント・アクティビティの取得方法を、取得期間と重なる時間があれば取得するように変更
- 1日の境界にあるイベント・アクティビティの高さの計算方法を修正
- イベント取得のテストの実装
- WindowLog取得のテストの実装

## 未実装
- ~イベント取得のテストが成功しない~
  - ~テストではイベントが取得できていない(アプリケーションでは取得できて正しい表示になっている)~
- ~アクティビティ取得のテスト~