### PR TITLE
fix: 設定で追加したラベルがタイムラインに即時反映されない

### DIFF
--- a/src/renderer/src/components/category/CategoryList.tsx
+++ b/src/renderer/src/components/category/CategoryList.tsx
@@ -8,6 +8,7 @@ import { TYPES } from '@renderer/types';
 import { Pageable } from '@shared/data/Page';
 import { CategoryEdit } from './CategoryEdit';
 import CircularProgress from '@mui/material/CircularProgress';
+import { useCategoryMap } from '@renderer/hooks/useCategoryMap';
 import { useCategoryPage } from '@renderer/hooks/useCategoryPage';
 
 const buildColumnData = (overlaps: Partial<CRUDColumnData<Category>>): CRUDColumnData<Category> => {
@@ -51,6 +52,7 @@ export const CategoryList = (): JSX.Element => {
       direction: DEFAULT_SORT_DIRECTION,
     })
   );
+  const { refresh } = useCategoryMap();
   const { page, isLoading } = useCategoryPage({ pageable });
   const [isDialogOpen, setDialogOpen] = useState(false);
   const [categoryId, setCategoryId] = useState<string | null>(null);
@@ -69,12 +71,14 @@ export const CategoryList = (): JSX.Element => {
   const handleDelete = async (row: Category): Promise<void> => {
     const categoryProxy = rendererContainer.get<ICategoryProxy>(TYPES.CategoryProxy);
     await categoryProxy.delete(row.id);
+    await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
 
   const handleBulkDelete = async (uniqueKeys: string[]): Promise<void> => {
     const categoryProxy = rendererContainer.get<ICategoryProxy>(TYPES.CategoryProxy);
     await categoryProxy.bulkDelete(uniqueKeys);
+    await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
 
@@ -90,6 +94,7 @@ export const CategoryList = (): JSX.Element => {
 
   const handleDialogSubmit = async (category: Category): Promise<void> => {
     console.log('CategoryList handleDialogSubmit', category);
+    await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
 

--- a/src/renderer/src/components/category/CategoryList.tsx
+++ b/src/renderer/src/components/category/CategoryList.tsx
@@ -11,6 +11,12 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { useCategoryMap } from '@renderer/hooks/useCategoryMap';
 import { useCategoryPage } from '@renderer/hooks/useCategoryPage';
 
+/**
+ * カラムデータ作成
+ * 
+ * @param overlaps: Partial<CRUDColumnData<Category>>
+ * @returns CRUDColumnData<Category>
+ */
 const buildColumnData = (overlaps: Partial<CRUDColumnData<Category>>): CRUDColumnData<Category> => {
   return {
     isKey: false,
@@ -22,6 +28,9 @@ const buildColumnData = (overlaps: Partial<CRUDColumnData<Category>>): CRUDColum
   };
 };
 
+/**
+ * ヘッダーの作成
+ */
 const headCells: readonly CRUDColumnData<Category>[] = [
   buildColumnData({
     id: 'name',
@@ -44,6 +53,22 @@ const DEFAULT_ORDER = 'name';
 const DEFAULT_SORT_DIRECTION = 'asc';
 const DEFAULT_PAGE_SIZE = 10;
 
+/**
+ * 設定-カテゴリー画面コンポーネント
+ * 
+ * 設定のカテゴリーを表示する。
+ * 
+ * (表示内容)
+ * ・追加ボタン
+ * ・カテゴリーリスト
+ *     - 選択チェックボックス
+ *     - カテゴリー情報
+ *     - 編集ボタン
+ *     - 削除ボタン
+ * ・ページネーション
+ * 
+ * @returns レンダリング結果
+ */
 export const CategoryList = (): JSX.Element => {
   console.log('CategoryList start');
   const [pageable, setPageable] = useState<Pageable>(
@@ -68,16 +93,28 @@ export const CategoryList = (): JSX.Element => {
     setDialogOpen(true);
   };
 
+  /**
+   * カテゴリー削除
+   * 
+   * @param row
+   */
   const handleDelete = async (row: Category): Promise<void> => {
     const categoryProxy = rendererContainer.get<ICategoryProxy>(TYPES.CategoryProxy);
     await categoryProxy.delete(row.id);
+    // データの最新化
     await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
 
+  /**
+   * 選択したチェックボックスのカテゴリー削除
+   * 
+   * @param uniqueKeys 
+   */
   const handleBulkDelete = async (uniqueKeys: string[]): Promise<void> => {
     const categoryProxy = rendererContainer.get<ICategoryProxy>(TYPES.CategoryProxy);
     await categoryProxy.bulkDelete(uniqueKeys);
+    // データの最新化
     await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
@@ -87,13 +124,22 @@ export const CategoryList = (): JSX.Element => {
     setPageable(newPageable);
   };
 
+  /**
+   * ダイアログのクローズ
+   */
   const handleDialogClose = (): void => {
     console.log('CategoryList handleDialogClose');
     setDialogOpen(false);
   };
 
+  /**
+   * カテゴリー追加・編集の送信
+   * 
+   * @param category 
+   */
   const handleDialogSubmit = async (category: Category): Promise<void> => {
     console.log('CategoryList handleDialogSubmit', category);
+    // データの最新化
     await refresh();
     setPageable(pageable.replacePageNumber(0));
   };

--- a/src/renderer/src/components/label/LabelList.tsx
+++ b/src/renderer/src/components/label/LabelList.tsx
@@ -11,6 +11,12 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { useLabelMap } from '@renderer/hooks/useLabelMap';
 import { useLabelPage } from '@renderer/hooks/useLabelPage';
 
+/**
+ * カラムデータ作成
+ * 
+ * @param overlaps: Partial<CRUDColumnData<Label>>
+ * @returns CRUDColumnData<Label>
+ */
 const buildColumnData = (overlaps: Partial<CRUDColumnData<Label>>): CRUDColumnData<Label> => {
   return {
     isKey: false,
@@ -22,6 +28,9 @@ const buildColumnData = (overlaps: Partial<CRUDColumnData<Label>>): CRUDColumnDa
   };
 };
 
+/**
+ * ヘッダーの作成
+ */
 const headCells: readonly CRUDColumnData<Label>[] = [
   buildColumnData({
     id: 'name',
@@ -44,6 +53,22 @@ const DEFAULT_ORDER = 'name';
 const DEFAULT_SORT_DIRECTION = 'asc';
 const DEFAULT_PAGE_SIZE = 10;
 
+/**
+ * 設定-ラベル画面コンポーネント
+ * 
+ * 設定のラベルを表示する。
+ * 
+ * (表示内容)
+ * ・追加ボタン
+ * ・ラベルリスト
+ *     - 選択チェックボックス
+ *     - ラベル情報
+ *     - 編集ボタン
+ *     - 削除ボタン
+ * ・ページネーション
+ * 
+ * @returns レンダリング結果
+ */
 export const LabelList = (): JSX.Element => {
   console.log('LabelList start');
   const [pageable, setPageable] = useState<Pageable>(
@@ -68,16 +93,28 @@ export const LabelList = (): JSX.Element => {
     setDialogOpen(true);
   };
 
+  /**
+   * ラベル削除
+   * 
+   * @param row
+   */
   const handleDelete = async (row: Label): Promise<void> => {
     const LabelProxy = rendererContainer.get<ILabelProxy>(TYPES.LabelProxy);
     await LabelProxy.delete(row.id);
+    // データの最新化
     await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
 
+  /**
+   * 選択したチェックボックスのラベル削除
+   * 
+   * @param uniqueKeys
+   */
   const handleBulkDelete = async (uniqueKeys: string[]): Promise<void> => {
     const LabelProxy = rendererContainer.get<ILabelProxy>(TYPES.LabelProxy);
     await LabelProxy.bulkDelete(uniqueKeys);
+    // データの最新化
     await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
@@ -87,13 +124,22 @@ export const LabelList = (): JSX.Element => {
     setPageable(newPageable);
   };
 
+  /**
+   * ダイアログのクローズ
+   */
   const handleDialogClose = (): void => {
     console.log('LabelList handleDialogClose');
     setDialogOpen(false);
   };
 
+  /**
+   * ラベル追加・編集の送信
+   * 
+   * @param label
+   */
   const handleDialogSubmit = async (label: Label): Promise<void> => {
     console.log('LabelList handleDialogSubmit', label);
+    // データの最新化
     await refresh();
     setPageable(pageable.replacePageNumber(0));
   };

--- a/src/renderer/src/components/label/LabelList.tsx
+++ b/src/renderer/src/components/label/LabelList.tsx
@@ -8,6 +8,7 @@ import { TYPES } from '@renderer/types';
 import { Pageable } from '@shared/data/Page';
 import { LabelEdit } from './LabelEdit';
 import CircularProgress from '@mui/material/CircularProgress';
+import { useLabelMap } from '@renderer/hooks/useLabelMap';
 import { useLabelPage } from '@renderer/hooks/useLabelPage';
 
 const buildColumnData = (overlaps: Partial<CRUDColumnData<Label>>): CRUDColumnData<Label> => {
@@ -51,6 +52,7 @@ export const LabelList = (): JSX.Element => {
       direction: DEFAULT_SORT_DIRECTION,
     })
   );
+  const { refresh } = useLabelMap();
   const { page, isLoading } = useLabelPage({ pageable });
   const [isDialogOpen, setDialogOpen] = useState(false);
   const [labelId, setLabelId] = useState<string | null>(null);
@@ -69,12 +71,14 @@ export const LabelList = (): JSX.Element => {
   const handleDelete = async (row: Label): Promise<void> => {
     const LabelProxy = rendererContainer.get<ILabelProxy>(TYPES.LabelProxy);
     await LabelProxy.delete(row.id);
+    await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
 
   const handleBulkDelete = async (uniqueKeys: string[]): Promise<void> => {
     const LabelProxy = rendererContainer.get<ILabelProxy>(TYPES.LabelProxy);
     await LabelProxy.bulkDelete(uniqueKeys);
+    await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
 
@@ -90,6 +94,7 @@ export const LabelList = (): JSX.Element => {
 
   const handleDialogSubmit = async (label: Label): Promise<void> => {
     console.log('LabelList handleDialogSubmit', label);
+    await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
 

--- a/src/renderer/src/components/project/ProjectList.tsx
+++ b/src/renderer/src/components/project/ProjectList.tsx
@@ -7,6 +7,7 @@ import { TYPES } from '@renderer/types';
 import { Pageable } from '@shared/data/Page';
 import { ProjectEdit } from './ProjectEdit';
 import CircularProgress from '@mui/material/CircularProgress';
+import { useProjectMap } from '@renderer/hooks/useProjectMap';
 import { useProjectPage } from '@renderer/hooks/useProjectPage';
 
 const buildColumnData = (overlaps: Partial<CRUDColumnData<Project>>): CRUDColumnData<Project> => {
@@ -43,6 +44,7 @@ export const ProjectList = (): JSX.Element => {
       direction: DEFAULT_SORT_DIRECTION,
     })
   );
+  const { refresh } = useProjectMap();
   const { page, isLoading } = useProjectPage({ pageable });
   const [isDialogOpen, setDialogOpen] = useState(false);
   const [projectId, setProjectId] = useState<string | null>(null);
@@ -61,12 +63,14 @@ export const ProjectList = (): JSX.Element => {
   const handleDelete = async (row: Project): Promise<void> => {
     const ProjectProxy = rendererContainer.get<IProjectProxy>(TYPES.ProjectProxy);
     await ProjectProxy.delete(row.id);
+    await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
 
   const handleBulkDelete = async (uniqueKeys: string[]): Promise<void> => {
     const ProjectProxy = rendererContainer.get<IProjectProxy>(TYPES.ProjectProxy);
     await ProjectProxy.bulkDelete(uniqueKeys);
+    await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
 
@@ -82,6 +86,7 @@ export const ProjectList = (): JSX.Element => {
 
   const handleDialogSubmit = async (project: Project): Promise<void> => {
     console.log('ProjectList handleDialogSubmit', project);
+    await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
 

--- a/src/renderer/src/components/project/ProjectList.tsx
+++ b/src/renderer/src/components/project/ProjectList.tsx
@@ -10,6 +10,12 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { useProjectMap } from '@renderer/hooks/useProjectMap';
 import { useProjectPage } from '@renderer/hooks/useProjectPage';
 
+/**
+ * カラムデータ作成
+ * 
+ * @param overlaps: Partial<CRUDColumnData<Project>>
+ * @returns CRUDColumnData<Project>
+ */
 const buildColumnData = (overlaps: Partial<CRUDColumnData<Project>>): CRUDColumnData<Project> => {
   return {
     isKey: false,
@@ -21,6 +27,9 @@ const buildColumnData = (overlaps: Partial<CRUDColumnData<Project>>): CRUDColumn
   };
 };
 
+/**
+ * ヘッダーの作成
+ */
 const headCells: readonly CRUDColumnData<Project>[] = [
   buildColumnData({
     id: 'name',
@@ -36,6 +45,22 @@ const DEFAULT_ORDER = 'name';
 const DEFAULT_SORT_DIRECTION = 'asc';
 const DEFAULT_PAGE_SIZE = 10;
 
+/**
+ * 設定-プロジェクト画面コンポーネント
+ * 
+ * 設定のプロジェクトを表示する。
+ * 
+ * (表示内容)
+ * ・追加ボタン
+ * ・ラベルリスト
+ *     - 選択チェックボックス
+ *     - プロジェクト情報
+ *     - 編集ボタン
+ *     - 削除ボタン
+ * ・ページネーション
+ * 
+ * @returns レンダリング結果
+ */
 export const ProjectList = (): JSX.Element => {
   console.log('ProjectList start');
   const [pageable, setPageable] = useState<Pageable>(
@@ -60,16 +85,28 @@ export const ProjectList = (): JSX.Element => {
     setDialogOpen(true);
   };
 
+  /**
+   * プロジェクト削除
+   * 
+   * @param row 
+   */
   const handleDelete = async (row: Project): Promise<void> => {
     const ProjectProxy = rendererContainer.get<IProjectProxy>(TYPES.ProjectProxy);
     await ProjectProxy.delete(row.id);
+    // データの最新化
     await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
 
+  /**
+   * 選択したチェックボックスのプロジェクト削除
+   * 
+   * @param uniqueKeys 
+   */
   const handleBulkDelete = async (uniqueKeys: string[]): Promise<void> => {
     const ProjectProxy = rendererContainer.get<IProjectProxy>(TYPES.ProjectProxy);
     await ProjectProxy.bulkDelete(uniqueKeys);
+    // データの最新化
     await refresh();
     setPageable(pageable.replacePageNumber(0));
   };
@@ -79,13 +116,22 @@ export const ProjectList = (): JSX.Element => {
     setPageable(newPageable);
   };
 
+  /**
+   * ダイアログのクローズ
+   */
   const handleDialogClose = (): void => {
     console.log('ProjectList handleDialogClose');
     setDialogOpen(false);
   };
 
+  /**
+   * プロジェクト追加・編集の送信
+   * 
+   * @param project 
+   */
   const handleDialogSubmit = async (project: Project): Promise<void> => {
     console.log('ProjectList handleDialogSubmit', project);
+    // データの最新化
     await refresh();
     setPageable(pageable.replacePageNumber(0));
   };


### PR DESCRIPTION
## チケット
#150 

## 実装内容

* 不具合対応
    * 不具合原因
        * 設定でのラベル追加・編集では、データの追加、編集、削除時にサーバーのデータを更新していますが、アプリのデータを最新化する`refetch`を実行していませんでした。そのため、アプリ内のデータが最新版に更新されていないことから、ラベルが即時反映されていませんでした。
    * 対応内容
        * 設定からラベルデータを更新する際に、`refetch`を実行するように修正しました。
        * 参考コード
            * [タイムラインのラベル追加処理のrefetch](https://github.com/minr-dev/desktop/blob/develop/src/renderer/src/components/label/LabelMultiSelectComponent.tsx#L76)
            * [タイムラインのカテゴリー追加処理のrefetch](https://github.com/minr-dev/desktop/blob/develop/src/renderer/src/components/category/CategoryDropdownComponent.tsx#L67)
            * [タイムラインのプロジェクト追加処理のrefetch](https://github.com/minr-dev/desktop/blob/develop/src/renderer/src/components/project/ProjectDropdownComponent.tsx#L69)

* 本対応で関連する処理についてコメントを追加