### PR TITLE
fix: 設定からラベルのカラーパレットをドラッグすると画面が表示されなくなる

### DIFF
--- a/src/renderer/src/components/common/fields/TextColorPickerField.tsx
+++ b/src/renderer/src/components/common/fields/TextColorPickerField.tsx
@@ -36,7 +36,6 @@ export const TextColorPickerField = ({
   };
 
   const handleChangeComplete = (color: ColorResult): void => {
-    setAnchorEl(null);
     onChangeComplete(color.hex);
   };
 
@@ -55,7 +54,7 @@ export const TextColorPickerField = ({
       <Menu
         id={`color-picker-menu-${field.id}`}
         anchorEl={anchorEl}
-        keepMounted
+        keepMounted={false}
         open={Boolean(anchorEl)}
         onClose={handleClosePicker}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}


### PR DESCRIPTION
## チケット
#151  

## 実装内容

* 不具合対応
    * 不具合原因
        * `TextColorPickerField.tsx`の`handleChangeComplete`にて色が変更された際に`anchorEl`をnullにすることでカラーパレットを閉じていました。カラーパレットは色を即時反映させるため、少し色を変えるだけで`anchorEl`がnullになり画面が閉じられることが不具合の原因でした。
    * 対応内容
        * 色が変更された際に`anchorEl`をnullにする処理を削除することで、パレットが閉じられないようにしました。
        * カラーパレットは画面外をクリックすることで閉じるため、閉じれないといった問題は発生しません。
        * 参考webサイト
            * [Reactでカラーピッカーの導入](https://engineer-blog.ajike.co.jp/react_color_picker/)