### PR TITLE
feat: アクティビティから自動的に作業を分類する

### DIFF
--- a/src/main/inversify.config.ts
+++ b/src/main/inversify.config.ts
@@ -65,6 +65,9 @@ import { ProjectServiceImpl } from './services/ProjectServiceImpl';
 import { IActivityUsageService } from './services/IActivityUsageService';
 import { ActivityUsageServiceImpl } from './services/ActicityUsageServiceImpl';
 import { ActivityUsageServiceHandlerImpl } from './ipc/ActivityUsageServiceHandlerImpl';
+import { IApplicationService } from './services/IApplicationService';
+import { ApplicationServiceImpl } from './services/ApplicationServiceImpl';
+import { ApplicationHandlerImpl } from './ipc/ApplicationHandlerImpl';
 
 // コンテナの作成
 const container = new Container();
@@ -126,6 +129,10 @@ container
   .bind<IIpcHandlerInitializer>(TYPES.IpcHandlerInitializer)
   .to(ProjectHandlerImpl)
   .inSingletonScope();
+container
+  .bind<IIpcHandlerInitializer>(TYPES.IpcHandlerInitializer)
+  .to(ApplicationHandlerImpl)
+  .inSingletonScope();
 
 // サービスとリポジトリのバインド
 container.bind<IUserDetailsService>(TYPES.UserDetailsService).to(UserDetailsServiceImpl);
@@ -147,6 +154,10 @@ container
 container.bind<ICategoryService>(TYPES.CategoryService).to(CategoryServiceImpl).inSingletonScope();
 container.bind<ILabelService>(TYPES.LabelService).to(LabelServiceImpl).inSingletonScope();
 container.bind<IProjectService>(TYPES.ProjectService).to(ProjectServiceImpl).inSingletonScope();
+container
+  .bind<IApplicationService>(TYPES.ApplicationService)
+  .to(ApplicationServiceImpl)
+  .inSingletonScope();
 container
   .bind<IUserPreferenceStoreService>(TYPES.UserPreferenceStoreService)
   .to(UserPreferenceStoreServiceImpl)

--- a/src/main/ipc/ApplicationHandlerImpl.ts
+++ b/src/main/ipc/ApplicationHandlerImpl.ts
@@ -1,0 +1,59 @@
+import { IpcChannel } from '@shared/constants';
+import { ipcMain } from 'electron';
+import { inject, injectable } from 'inversify';
+import { TYPES } from '@main/types';
+import type { IIpcHandlerInitializer } from './IIpcHandlerInitializer';
+import type { IApplicationService } from '@main/services/IApplicationService';
+import { PageResponse, Pageable } from '@shared/data/Page';
+import { handleDatabaseOperation } from './dbHandlerUtil';
+import { Application } from '@shared/data/Application';
+
+/**
+ * Applicationのデータの取得用の IPC ハンドラー
+ */
+@injectable()
+export class ApplicationHandlerImpl implements IIpcHandlerInitializer {
+  constructor(
+    @inject(TYPES.ApplicationService)
+    private readonly applicationService: IApplicationService
+  ) {}
+
+  init(): void {
+    ipcMain.handle(IpcChannel.APPLICATION_LIST, async (_event, pageRequest) => {
+      return handleDatabaseOperation(async (): Promise<PageResponse<Application>> => {
+        const page = await this.applicationService.list(Pageable.fromPageRequest(pageRequest));
+        return page.toPageResponse();
+      });
+    });
+
+    ipcMain.handle(IpcChannel.APPLICATION_GET, async (_event, id) => {
+      return handleDatabaseOperation(async (): Promise<Application | null> => {
+        return await this.applicationService.get(id);
+      });
+    });
+
+    ipcMain.handle(IpcChannel.APPLICATION_SAVE, async (_event, Application) => {
+      return handleDatabaseOperation(async (): Promise<Application> => {
+        return await this.applicationService.save(Application);
+      });
+    });
+
+    ipcMain.handle(IpcChannel.APPLICATION_DELETE, async (_event, id) => {
+      return handleDatabaseOperation(async (): Promise<void> => {
+        return await this.applicationService.delete(id);
+      });
+    });
+
+    ipcMain.handle(IpcChannel.APPLICATION_BULK_DELETE, async (_event, ids) => {
+      return handleDatabaseOperation(async (): Promise<void> => {
+        return await this.applicationService.bulkDelete(ids);
+      });
+    });
+
+    ipcMain.handle(IpcChannel.APPLICATION_GET_BY_NAME, async (_event, ids) => {
+      return handleDatabaseOperation(async (): Promise<Application | null> => {
+        return await this.applicationService.getByName(ids);
+      });
+    });
+  }
+}

--- a/src/main/ipc/EventEntryServiceHandlerImpl.ts
+++ b/src/main/ipc/EventEntryServiceHandlerImpl.ts
@@ -7,12 +7,15 @@ import { TYPES } from '@main/types';
 import { EventEntryFactory } from '@main/services/EventEntryFactory';
 import { EVENT_TYPE, EventEntry } from '@shared/data/EventEntry';
 import { EventDateTime } from '@shared/data/EventDateTime';
+import { DateUtil } from '@shared/utils/DateUtil';
 
 @injectable()
 export class EventEntryServiceHandlerImpl implements IIpcHandlerInitializer {
   constructor(
     @inject(TYPES.EventEntryService)
-    private readonly eventEntryService: IEventEntryService
+    private readonly eventEntryService: IEventEntryService,
+    @inject(TYPES.DateUtil)
+    private readonly dateUtil: DateUtil
   ) {}
 
   init(): void {
@@ -36,7 +39,8 @@ export class EventEntryServiceHandlerImpl implements IIpcHandlerInitializer {
         eventType: EVENT_TYPE,
         summary: string,
         start: EventDateTime,
-        end: EventDateTime
+        end: EventDateTime,
+        isProvisional?: boolean
       ) => {
         const data = EventEntryFactory.create({
           userId: userId,
@@ -44,6 +48,7 @@ export class EventEntryServiceHandlerImpl implements IIpcHandlerInitializer {
           summary: summary,
           start: start,
           end: end,
+          isProvisional: isProvisional ?? false,
         });
         return Promise.resolve(data);
       }
@@ -58,7 +63,7 @@ export class EventEntryServiceHandlerImpl implements IIpcHandlerInitializer {
      */
     ipcMain.handle(IpcChannel.EVENT_ENTRY_SAVE, async (_event, eventEntry: EventEntry) => {
       if (eventEntry.externalEventEntryId) {
-        eventEntry.lastSynced = new Date();
+        eventEntry.lastSynced = this.dateUtil.getCurrentDate();
       }
       return await this.eventEntryService.save(eventEntry);
     });

--- a/src/main/services/ApplicationServiceImpl.ts
+++ b/src/main/services/ApplicationServiceImpl.ts
@@ -1,0 +1,84 @@
+import { Application } from '@shared/data/Application';
+import { IApplicationService } from './IApplicationService';
+import { inject, injectable } from 'inversify';
+import { TYPES } from '@main/types';
+import { DataSource } from './DataSource';
+import { Page, Pageable } from '@shared/data/Page';
+import type { IUserDetailsService } from './IUserDetailsService';
+import { UniqueConstraintError } from '@shared/errors/UniqueConstraintError';
+
+@injectable()
+export class ApplicationServiceImpl implements IApplicationService {
+  constructor(
+    @inject(TYPES.DataSource)
+    private readonly dataSource: DataSource<Application>,
+    @inject(TYPES.UserDetailsService)
+    private readonly userDetailsService: IUserDetailsService
+  ) {
+    this.dataSource.createDb(this.tableName, [
+      { fieldName: 'id', unique: true },
+      { fieldName: 'basename', unique: true },
+    ]);
+  }
+
+  get tableName(): string {
+    return 'application.db';
+  }
+
+  async list(pageable: Pageable): Promise<Page<Application>> {
+    const userId = await this.userDetailsService.getUserId();
+    const query = { minr_user_id: userId };
+    const sort = {};
+    if (pageable.sort) {
+      sort[pageable.sort.property] = pageable.sort.direction === 'asc' ? 1 : -1;
+    }
+    const totalElements = await this.dataSource.count(this.tableName, query);
+    const content = await this.dataSource.find(
+      this.tableName,
+      query,
+      sort,
+      pageable.pageNumber * pageable.pageSize,
+      pageable.pageSize
+    );
+    return new Page<Application>(content, totalElements, pageable);
+  }
+
+  async get(id: string): Promise<Application> {
+    const userId = await this.userDetailsService.getUserId();
+    return await this.dataSource.get(this.tableName, { id: id, minr_user_id: userId });
+  }
+
+  async save(Application: Application): Promise<Application> {
+    const userId = await this.userDetailsService.getUserId();
+    const data = { ...Application, minr_user_id: userId };
+    if (!data.id || data.id.length === 0) {
+      data.id = await this.dataSource.generateUniqueId();
+    }
+    try {
+      return await this.dataSource.upsert(this.tableName, data);
+    } catch (e) {
+      if (this.dataSource.isUniqueConstraintViolated(e)) {
+        throw new UniqueConstraintError(
+          `Application basename must be unique: ${Application.basename}`,
+          e as Error
+        );
+      }
+      throw e;
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    const userId = await this.userDetailsService.getUserId();
+    return await this.dataSource.delete(this.tableName, { id: id, minr_user_id: userId });
+  }
+
+  async bulkDelete(ids: string[]): Promise<void> {
+    const userId = await this.userDetailsService.getUserId();
+    return await this.dataSource.delete(this.tableName, { id: { $in: ids }, minr_user_id: userId });
+  }
+
+  async getByName(basename: string): Promise<Application> {
+    const userId = await this.userDetailsService.getUserId();
+    return await this.dataSource.get(this.tableName, { basename: basename, minr_user_id: userId });
+  }
+}

--- a/src/main/services/EventEntryFactory.ts
+++ b/src/main/services/EventEntryFactory.ts
@@ -27,6 +27,7 @@ export class EventEntryFactory {
       end: external.end,
       description: external.description,
       location: external.location,
+      isProvisional: false,
       externalEventEntryId: external.id,
       lastSynced: external.updated,
     });

--- a/src/main/services/IApplicationService.ts
+++ b/src/main/services/IApplicationService.ts
@@ -1,0 +1,11 @@
+import { Application } from '@shared/data/Application';
+import { Page, Pageable } from '@shared/data/Page';
+
+export interface IApplicationService {
+  list(pageable: Pageable): Promise<Page<Application>>;
+  get(id: string): Promise<Application>;
+  save(Application: Application): Promise<Application>;
+  delete(id: string): Promise<void>;
+  bulkDelete(ids: string[]): Promise<void>;
+  getByName(basename: string): Promise<Application | null>;
+}

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -15,6 +15,7 @@ export const TYPES = {
   CategoryService: Symbol.for('CategoryService'),
   LabelService: Symbol.for('LabelService'),
   ProjectService: Symbol.for('ProjectService'),
+  ApplicationService: Symbol.for('ApplicationService'),
   GitHubCredentialsStoreService: Symbol.for('GitHubCredentialsStoreService'),
   UserPreferenceStoreService: Symbol.for('UserPreferenceStoreService'),
   EventEntryService: Symbol.for('EventEntryService'),

--- a/src/renderer/src/components/application/ApplicationEdit.tsx
+++ b/src/renderer/src/components/application/ApplicationEdit.tsx
@@ -1,8 +1,8 @@
 import rendererContainer from '../../inversify.config';
-import { Alert, Autocomplete, Chip, Grid, Stack, TextField } from '@mui/material';
+import { Alert, Grid, Stack, TextField } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { CRUDFormDialog } from '../crud/CRUDFormDialog';
-import { Controller, useForm, useWatch } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { Application } from '@shared/data/Application';
 import { TYPES } from '@renderer/types';
 import { IApplicationProxy } from '@renderer/services/IApplicationProxy';

--- a/src/renderer/src/components/application/ApplicationEdit.tsx
+++ b/src/renderer/src/components/application/ApplicationEdit.tsx
@@ -1,0 +1,184 @@
+import rendererContainer from '../../inversify.config';
+import { Alert, Autocomplete, Chip, Grid, Stack, TextField } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import { CRUDFormDialog } from '../crud/CRUDFormDialog';
+import { Controller, useForm, useWatch } from 'react-hook-form';
+import { Application } from '@shared/data/Application';
+import { TYPES } from '@renderer/types';
+import { IApplicationProxy } from '@renderer/services/IApplicationProxy';
+import { ReadOnlyTextField } from '../common/fields/ReadOnlyTextField';
+import { UniqueConstraintError } from '@shared/errors/UniqueConstraintError';
+import { AppError } from '@shared/errors/AppError';
+import { CategoryDropdownComponent } from '../category/CategoryDropdownComponent';
+import { DateUtil } from '@shared/utils/DateUtil';
+import { ProjectDropdownComponent } from '../project/ProjectDropdownComponent';
+import { LabelMultiSelectComponent } from '../label/LabelMultiSelectComponent';
+
+interface ApplicationFormData {
+  id: string;
+  basename: string;
+  relatedProjectId: string;
+  relatedCategoryId: string;
+  relatedLabelIds: string[];
+}
+
+interface ApplicationEditProps {
+  isOpen: boolean;
+  ApplicationId: string | null;
+  onClose: () => void;
+  onSubmit: (Application: Application) => void;
+}
+
+export const ApplicationEdit = ({
+  isOpen,
+  ApplicationId: applicationId,
+  onClose,
+  onSubmit,
+}: ApplicationEditProps): JSX.Element => {
+  console.log('ApplicationEdit', isOpen);
+  const [isDialogOpen, setDialogOpen] = useState(isOpen);
+  const [application, setApplication] = useState<Application | null>(null);
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors: formErrors },
+    setError,
+  } = useForm<ApplicationFormData>();
+
+  useEffect(() => {
+    const fetchData = async (): Promise<void> => {
+      console.log('ApplicationEdit fetchData', applicationId);
+      const applicationProxy = rendererContainer.get<IApplicationProxy>(TYPES.ApplicationProxy);
+      let application: Application | null = null;
+      if (applicationId !== null) {
+        application = await applicationProxy.get(applicationId);
+      }
+      reset(application ? application : {});
+      setApplication(application);
+    };
+    fetchData();
+    setDialogOpen(isOpen);
+  }, [isOpen, applicationId, reset]);
+
+  const handleDialogSubmit = async (data: ApplicationFormData): Promise<void> => {
+    console.log('ApplicationEdit handleDialogSubmit', data);
+    const dateUtil = rendererContainer.get<DateUtil>(TYPES.DateUtil);
+    // mongodb や nedb の場合、 _id などのエンティティとしては未定義の項目が埋め込まれていることがあり
+    // それらの項目を使って更新処理が行われるため、`...Application` で隠れた項目もコピーされるようにする
+    const newApplication: Application = {
+      ...application,
+      ...data,
+      id: application ? application.id : '',
+      updated: dateUtil.getCurrentDate(),
+    };
+    try {
+      const ApplicationProxy = rendererContainer.get<IApplicationProxy>(TYPES.ApplicationProxy);
+      const saved = await ApplicationProxy.save(newApplication);
+      await onSubmit(saved);
+      onClose();
+      reset();
+    } catch (error) {
+      console.error('ApplicationEdit handleDialogSubmit error', error);
+      const errName = AppError.getErrorName(error);
+      if (errName === UniqueConstraintError.NAME) {
+        setError('basename', {
+          type: 'manual',
+          message: 'アプリケーション名は既に登録されています',
+        });
+      } else {
+        throw error;
+      }
+    }
+  };
+
+  const handleDialogClose = (): void => {
+    console.log('ApplicationEdit handleDialogClose');
+    onClose();
+  };
+
+  return (
+    <CRUDFormDialog
+      isOpen={isDialogOpen}
+      title={`アプリケーション${applicationId !== null ? '編集' : '追加'}`}
+      onSubmit={handleSubmit(handleDialogSubmit)}
+      onClose={handleDialogClose}
+    >
+      <Grid container spacing={2}>
+        {applicationId !== null && (
+          <Grid item xs={12} key="applicationId">
+            <Controller
+              name="id"
+              control={control}
+              render={({ field }): React.ReactElement => (
+                <ReadOnlyTextField field={field} label="ID" />
+              )}
+            />
+          </Grid>
+        )}
+        <Grid item xs={12}>
+          <Controller
+            name="basename"
+            control={control}
+            rules={{ required: '入力してください。' }}
+            render={({ field, fieldState: { error } }): React.ReactElement => (
+              <TextField
+                {...field}
+                label="アプリケーション名"
+                variant="outlined"
+                error={!!error}
+                helperText={error?.message}
+                fullWidth
+                margin="normal"
+              />
+            )}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <Controller
+            name={`relatedProjectId`}
+            control={control}
+            render={({ field: { onChange, value } }): JSX.Element => (
+              <ProjectDropdownComponent value={value} onChange={onChange} />
+            )}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <Controller
+            name={`relatedCategoryId`}
+            control={control}
+            render={({ field: { onChange, value } }): JSX.Element => (
+              <CategoryDropdownComponent value={value} onChange={onChange} />
+            )}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <Controller
+            name={`relatedLabelIds`}
+            control={control}
+            render={({ field }): JSX.Element => (
+              <LabelMultiSelectComponent
+                field={field}
+                value={field.value}
+                onChange={field.onChange}
+              />
+            )}
+          />
+        </Grid>
+
+        <Stack>
+          {Object.entries(formErrors).length > 0 && (
+            <Alert severity="error">入力エラーを修正してください</Alert>
+          )}
+          {/* デバッグのときにエラーを表示する */}
+          {/* {process.env.NODE_ENV !== 'production' &&
+          Object.entries(formErrors).map(([fieldName, error]) => (
+            <Alert key={fieldName} severity="error">
+              {fieldName}: {error.message}
+            </Alert>
+          ))} */}
+        </Stack>
+      </Grid>
+    </CRUDFormDialog>
+  );
+};

--- a/src/renderer/src/components/application/ApplicationList.tsx
+++ b/src/renderer/src/components/application/ApplicationList.tsx
@@ -1,0 +1,206 @@
+import rendererContainer from '../../inversify.config';
+import { Application } from '@shared/data/Application';
+import { CRUDList, CRUDColumnData } from '../crud/CRUDList';
+import { useState } from 'react';
+import { IApplicationProxy } from '@renderer/services/IApplicationProxy';
+import { TYPES } from '@renderer/types';
+import { Pageable } from '@shared/data/Page';
+import { ApplicationEdit } from './ApplicationEdit';
+import CircularProgress from '@mui/material/CircularProgress';
+import { useApplicationPage } from '@renderer/hooks/useApplicationPage';
+import { useCategoryMap } from '@renderer/hooks/useCategoryMap';
+import { Chip } from '@mui/material';
+import { useProjectMap } from '@renderer/hooks/useProjectMap';
+import { useLabelMap } from '@renderer/hooks/useLabelMap';
+import { useApplicationMap } from '@renderer/hooks/useApplicationMap';
+
+const DEFAULT_ORDER = 'basename';
+const DEFAULT_SORT_DIRECTION = 'asc';
+const DEFAULT_PAGE_SIZE = 10;
+
+export const ApplicationList = (): JSX.Element => {
+  console.log('ApplicationList start');
+  const [pageable, setPageable] = useState<Pageable>(
+    new Pageable(0, DEFAULT_PAGE_SIZE, {
+      property: DEFAULT_ORDER,
+      direction: DEFAULT_SORT_DIRECTION,
+    })
+  );
+  const { page, isLoading } = useApplicationPage({ pageable });
+  const [isDialogOpen, setDialogOpen] = useState(false);
+  const [ApplicationId, setApplicationId] = useState<string | null>(null);
+
+  const { refresh } = useApplicationMap();
+  const { projectMap } = useProjectMap();
+  const { categoryMap } = useCategoryMap();
+  const { labelMap } = useLabelMap();
+
+  const buildColumnData = (
+    overlaps: Partial<CRUDColumnData<Application>>
+  ): CRUDColumnData<Application> => {
+    return {
+      isKey: false,
+      id: 'unknown',
+      numeric: false,
+      disablePadding: true,
+      label: 'unknown',
+      ...overlaps,
+    };
+  };
+
+  const headCells: readonly CRUDColumnData<Application>[] = [
+    buildColumnData({
+      id: 'basename',
+      label: 'アプリケーション名',
+    }),
+    buildColumnData({
+      id: 'relatedProjectId',
+      label: '関連プロジェクト',
+      callback: (data: Application): JSX.Element => {
+        const project = projectMap.get(data.relatedProjectId);
+        if (project == null) {
+          return <></>;
+        }
+        return <Chip key={project.id} label={project.name} />;
+      },
+    }),
+    buildColumnData({
+      id: 'relatedCategoryId',
+      label: '関連カテゴリー',
+      callback: (data: Application): JSX.Element => {
+        const category = categoryMap.get(data.relatedCategoryId);
+        if (category == null) {
+          return <></>;
+        }
+        return (
+          <Chip
+            key={category.id}
+            label={category.name}
+            style={{
+              backgroundColor: category.color,
+            }}
+          />
+        );
+      },
+    }),
+    buildColumnData({
+      id: 'relatedLabelIds',
+      label: '関連ラベル',
+      callback: (data: Application): JSX.Element => {
+        const labels =
+          data.relatedLabelIds
+            ?.map((labelId) => labelMap.get(labelId))
+            ?.filter((label) => label != null) ?? [];
+        return (
+          <>
+            {labels.map((label) => (
+              <Chip
+                key={label.id}
+                label={label.name}
+                style={{
+                  backgroundColor: label.color,
+                }}
+              />
+            ))}
+          </>
+        );
+      },
+    }),
+  ];
+
+  const handleAdd = async (): Promise<void> => {
+    console.log('handleAdd');
+    setApplicationId(null);
+    setDialogOpen(true);
+  };
+
+  const handleEdit = async (row: Application): Promise<void> => {
+    setApplicationId(row.id);
+    setDialogOpen(true);
+  };
+
+  /**
+   * アプリケーション削除
+   *
+   * @param row
+   */
+  const handleDelete = async (row: Application): Promise<void> => {
+    const ApplicationProxy = rendererContainer.get<IApplicationProxy>(TYPES.ApplicationProxy);
+    await ApplicationProxy.delete(row.id);
+    // データの最新化
+    await refresh();
+    setPageable(pageable.replacePageNumber(0));
+  };
+
+  /**
+   * 選択したチェックボックスのアプリケーション削除
+   *
+   * @param uniqueKeys
+   */
+  const handleBulkDelete = async (uniqueKeys: string[]): Promise<void> => {
+    const ApplicationProxy = rendererContainer.get<IApplicationProxy>(TYPES.ApplicationProxy);
+    await ApplicationProxy.bulkDelete(uniqueKeys);
+    // データの最新化
+    await refresh();
+    setPageable(pageable.replacePageNumber(0));
+  };
+
+  const handleChangePageable = async (newPageable: Pageable): Promise<void> => {
+    console.log('ApplicationList handleChangePageable newPageable', newPageable);
+    setPageable(newPageable);
+  };
+
+  /**
+   * ダイアログのクローズ
+   */
+  const handleDialogClose = (): void => {
+    console.log('ApplicationList handleDialogClose');
+    setDialogOpen(false);
+  };
+
+  /**
+   * アプリケーション追加・編集の送信
+   *
+   * @param Application
+   */
+  const handleDialogSubmit = async (Application: Application): Promise<void> => {
+    console.log('ApplicationList handleDialogSubmit', Application);
+    // データの最新化
+    await refresh();
+    setPageable(pageable.replacePageNumber(0));
+  };
+
+  if (isLoading) {
+    console.log('isLoading', isLoading);
+    return <CircularProgress />;
+  }
+
+  if (page === null) {
+    return <></>;
+  }
+
+  return (
+    <>
+      <CRUDList<Application>
+        title={'アプリケーション'}
+        page={page}
+        dense={false}
+        isDenseEnabled={false}
+        headCells={headCells}
+        onAdd={handleAdd}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        onBulkDelete={handleBulkDelete}
+        onChangePageable={handleChangePageable}
+      />
+      {isDialogOpen && (
+        <ApplicationEdit
+          isOpen={isDialogOpen}
+          ApplicationId={ApplicationId}
+          onClose={handleDialogClose}
+          onSubmit={handleDialogSubmit}
+        />
+      )}
+    </>
+  );
+};

--- a/src/renderer/src/components/application/ApplicationList.tsx
+++ b/src/renderer/src/components/application/ApplicationList.tsx
@@ -13,6 +13,7 @@ import { Chip } from '@mui/material';
 import { useProjectMap } from '@renderer/hooks/useProjectMap';
 import { useLabelMap } from '@renderer/hooks/useLabelMap';
 import { useApplicationMap } from '@renderer/hooks/useApplicationMap';
+import { Label } from '@shared/data/Label';
 
 const DEFAULT_ORDER = 'basename';
 const DEFAULT_SORT_DIRECTION = 'asc';
@@ -90,7 +91,7 @@ export const ApplicationList = (): JSX.Element => {
         const labels =
           data.relatedLabelIds
             ?.map((labelId) => labelMap.get(labelId))
-            ?.filter((label) => label != null) ?? [];
+            ?.filter((label): label is Label => label != null) ?? [];
         return (
           <>
             {labels.map((label) => (

--- a/src/renderer/src/components/timeTable/ActivityTimeline.tsx
+++ b/src/renderer/src/components/timeTable/ActivityTimeline.tsx
@@ -242,17 +242,15 @@ const ActivityTimelineItem = (
               .replace(/minutes?/, '分')
               .replace(/seconds?/, '秒');
             return (
-              <>
-                <Typography key={`title-${index}`} variant="body2" component="div">
-                  <Chip
-                    label={durationStr}
-                    size="small"
-                    variant="outlined"
-                    sx={{ marginRight: '0.5rem' }}
-                  />
-                  {d.windowTitle}
-                </Typography>
-              </>
+              <Typography key={`title-${index}`} variant="body2" component="div">
+                <Chip
+                  label={durationStr}
+                  size="small"
+                  variant="outlined"
+                  sx={{ marginRight: '0.5rem' }}
+                />
+                {d.windowTitle}
+              </Typography>
             );
           })}
         </TimelineContent>

--- a/src/renderer/src/components/timeTable/EventEntryForm.tsx
+++ b/src/renderer/src/components/timeTable/EventEntryForm.tsx
@@ -64,6 +64,7 @@ interface EventEntryFormProps {
  * TODO:
  * - プロジェクトのプルダウンの pageSize よりもデータが多いときにどうするかは要検討。
  * - 同じくソートの仕様も要検討。
+ * - 仮実績の保存をした時点でDBへの保存をするか(またはDBへの保存を仮実績の本登録に集約するか)
  *
  * @param {ProjectDropdownComponentProps} props - コンポーネントのプロパティ。
  * @returns {JSX.Element} レンダリング結果。
@@ -82,6 +83,7 @@ const EventEntryForm = ({
   console.log('EventEntryForm', isOpen, eventEntry);
   const defaultValues = { ...eventEntry };
   const targetDateTime = targetDate?.getTime();
+  const isProvisional = eventEntry?.isProvisional;
   if (targetDate && mode === FORM_MODE.NEW) {
     defaultValues.start = {
       dateTime: addHours(startOfDay(targetDate), startHour),
@@ -174,27 +176,31 @@ const EventEntryForm = ({
     const inputData = { ...data, eventType: eventType };
     try {
       const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);
-      if (data.id && String(data.id).length > 0) {
+      let ee: EventEntry | undefined;
+      if (isProvisional) {
+        ee = eventEntry;
+      } else if (data.id && String(data.id).length > 0) {
         const id = `${data.id}`;
-        const ee = await eventEntryProxy.get(id);
+        ee = await eventEntryProxy.get(id);
         if (!ee) {
           throw new Error(`EventEntry not found. id=${id}`);
         }
-        const merged = { ...ee, ...inputData };
-        const saved = await eventEntryProxy.save(merged);
-        await onSubmit(saved);
       } else {
         // TODO EventDateTime の対応
-        const ee = await eventEntryProxy.create(
+        ee = await eventEntryProxy.create(
           userDetails.userId,
           inputData.eventType,
           inputData.summary,
           inputData.start,
           inputData.end
         );
-        const merged = { ...ee, ...inputData };
+      }
+      const merged = { ...ee, ...inputData };
+      if (!isProvisional) {
         const saved = await eventEntryProxy.save(merged);
         await onSubmit(saved);
+      } else {
+        await onSubmit(merged);
       }
     } catch (err) {
       console.error(err);
@@ -214,8 +220,10 @@ const EventEntryForm = ({
     const deletedId = eventEntry.id;
     console.log('deletedId', deletedId);
     try {
-      const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);
-      await eventEntryProxy.delete(deletedId);
+      if (!eventEntry.isProvisional) {
+        const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);
+        await eventEntryProxy.delete(deletedId);
+      }
       await onDelete();
     } catch (err) {
       console.error(err);

--- a/src/renderer/src/components/timeTable/EventSlotText.tsx
+++ b/src/renderer/src/components/timeTable/EventSlotText.tsx
@@ -18,6 +18,17 @@ export const EventSlotText = ({ eventTimeCell }: EventSlotTextProps): JSX.Elemen
 
   const chips: JSX.Element[] = [];
 
+  if (eventTimeCell.event.isProvisional) {
+    chips.push(
+      <Chip
+        key={`provisional`}
+        label={'仮'}
+        style={{ marginRight: '2px', backgroundColor: 'white' }}
+        variant="outlined"
+      />
+    );
+  }
+
   if (!isProjectLoading && eventTimeCell.event.projectId) {
     const project = projectMap.get(eventTimeCell.event.projectId);
     if (project) {

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -140,17 +140,20 @@ const TimeTable = (): JSX.Element => {
     const now = rendererContainer.get<DateUtil>(TYPES.DateUtil).getCurrentDate();
     // 日付は1日の開始時刻で保存する
     setSelectedDate(getStartDate(now, startHourLocal));
+    setIsProdivisional(false);
   };
 
   const handlePrevDay = (): void => {
     if (selectedDate) {
       setSelectedDate(addDays(selectedDate, -1));
+      setIsProdivisional(false);
     }
   };
 
   const handleNextDay = (): void => {
     if (selectedDate) {
       setSelectedDate(addDays(selectedDate, 1));
+      setIsProdivisional(false);
     }
   };
 
@@ -159,6 +162,7 @@ const TimeTable = (): JSX.Element => {
     if (date !== null) {
       // 日付は1日の開始時刻で保存する
       setSelectedDate(getStartDate(date, startHourLocal));
+      setIsProdivisional(false);
     }
   };
 

--- a/src/renderer/src/hooks/useApplicationMap.ts
+++ b/src/renderer/src/hooks/useApplicationMap.ts
@@ -1,0 +1,45 @@
+import rendererContainer from '@renderer/inversify.config';
+import { Pageable } from '@shared/data/Page';
+import { Application } from '@shared/data/Application';
+import { TYPES } from '@renderer/types';
+import { useQuery } from 'react-query';
+import { IApplicationProxy } from '@renderer/services/IApplicationProxy';
+import { CacheKey } from './cacheKey';
+
+const PAGEABLE = new Pageable(0, Number.MAX_SAFE_INTEGER);
+const EMPTY_MAP = new Map<string, Application>();
+
+interface UseApplicationMapResult {
+  applicationMap: Map<string, Application>;
+  refresh: () => Promise<void>;
+  error: unknown;
+  isLoading: boolean;
+}
+
+/**
+ * アプリケーション の全件を取得してマップにするフック。
+ */
+export const useApplicationMap: () => UseApplicationMapResult = () => {
+  console.log('useApplicationMap');
+  const { data, error, isLoading, refetch } = useQuery(CacheKey.PROJECTS, fetchApplications);
+  const map = data ?? EMPTY_MAP;
+
+  // 内部で refetch をラップする。
+  // これにより refetch の戻り値の型が露出させない。機能的な意味はない。
+  const refresh = async (): Promise<void> => {
+    await refetch();
+  };
+
+  return { applicationMap: map, refresh, error, isLoading };
+};
+
+const fetchApplications = async (): Promise<Map<string, Application>> => {
+  console.log('fetchApplications');
+  const proxy = rendererContainer.get<IApplicationProxy>(TYPES.ApplicationProxy);
+  const result = await proxy.list(PAGEABLE);
+  const labelMap = new Map<string, Application>();
+  result.content.forEach((label) => {
+    labelMap.set(label.id, label);
+  });
+  return labelMap;
+};

--- a/src/renderer/src/hooks/useApplicationPage.ts
+++ b/src/renderer/src/hooks/useApplicationPage.ts
@@ -1,0 +1,38 @@
+import rendererContainer from '@renderer/inversify.config';
+import { Page, Pageable } from '@shared/data/Page';
+import { ICRUDProxy } from '@renderer/services/ICRUDProxy';
+import { Application } from '@shared/data/Application';
+import { TYPES } from '@renderer/types';
+import { useFetchCRUDData } from './useFetchCRUDData';
+import { useApplicationMap } from './useApplicationMap';
+
+interface UseApplicationPageProps {
+  pageable: Pageable;
+}
+
+interface UseApplicationPageResult {
+  page: Page<Application> | null;
+  refreshPage: () => Promise<void>;
+  isLoading: boolean;
+}
+
+/**
+ * アプリケーション の全件を取得するためのフック。
+ */
+export const useApplicationPage: (props: UseApplicationPageProps) => UseApplicationPageResult = ({
+  pageable,
+}) => {
+  const { refresh: refreshMap } = useApplicationMap();
+  const crudProxy = rendererContainer.get<ICRUDProxy<Application>>(TYPES.ApplicationProxy);
+  const { page, refreshPage, isLoading } = useFetchCRUDData<Application>({
+    pageable,
+    crudProxy,
+  });
+
+  const wrapRefreshPage = async (): Promise<void> => {
+    await refreshPage();
+    await refreshMap();
+  };
+
+  return { page, refreshPage: wrapRefreshPage, isLoading };
+};

--- a/src/renderer/src/hooks/useEventEntries.ts
+++ b/src/renderer/src/hooks/useEventEntries.ts
@@ -78,11 +78,9 @@ const useEventEntries = (targetDate?: Date): UseEventEntriesResult => {
       const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);
       const fetchedEvents = await eventEntryProxy.list(userDetails.userId, startDate, endDate);
 
-      // 仮登録のイベントはDBにないので更新時に持ち越す
-      setEvents((events) => {
-        const provisionalEvents = events?.filter((event) => event.isProvisional) ?? [];
-        return [...provisionalEvents, ...fetchedEvents.filter((event) => !event.deleted)];
-      });
+      // TODO: 仮登録のイベントの保持
+      // 日付変更時は保持しなくてよいが、GitHubなどとの同期の時は保持されているべき
+      setEvents(fetchedEvents.filter((event) => !event.deleted));
     } catch (error) {
       console.error('Failed to load user preference', error);
     }

--- a/src/renderer/src/inversify.config.ts
+++ b/src/renderer/src/inversify.config.ts
@@ -35,6 +35,8 @@ import { ActivityUsageProxyImpl } from './services/ActivityUsageProxyImpl';
 import { INotificationService } from './services/INotificationService';
 import { NotificationServiceImpl } from './services/NotificationServiceImpl';
 import { TimerManager } from '@shared/utils/TimerManager';
+import { IApplicationProxy } from './services/IApplicationProxy';
+import { ApplicationProxyImpl } from './services/ApplicationProxyImpl';
 
 // コンテナの作成
 const container = new Container();
@@ -70,6 +72,10 @@ container
 container.bind<ICategoryProxy>(TYPES.CategoryProxy).to(CategoryProxyImpl).inSingletonScope();
 container.bind<ILabelProxy>(TYPES.LabelProxy).to(LabelProxyImpl).inSingletonScope();
 container.bind<IProjectProxy>(TYPES.ProjectProxy).to(ProjectProxyImpl).inSingletonScope();
+container
+  .bind<IApplicationProxy>(TYPES.ApplicationProxy)
+  .to(ApplicationProxyImpl)
+  .inSingletonScope();
 container
   .bind<ISynchronizerProxy>(TYPES.CalendarSynchronizerProxy)
   .to(CalendarSynchronizerProxyImpl)

--- a/src/renderer/src/inversify.config.ts
+++ b/src/renderer/src/inversify.config.ts
@@ -35,6 +35,8 @@ import { ActivityUsageProxyImpl } from './services/ActivityUsageProxyImpl';
 import { INotificationService } from './services/INotificationService';
 import { NotificationServiceImpl } from './services/NotificationServiceImpl';
 import { TimerManager } from '@shared/utils/TimerManager';
+import { IAutoRegisterActualService } from './services/IAutoRegisterActualService';
+import { AutoRegisterActualService } from './services/AutoRegisterActuralService';
 import { IApplicationProxy } from './services/IApplicationProxy';
 import { ApplicationProxyImpl } from './services/ApplicationProxyImpl';
 
@@ -95,6 +97,10 @@ container
 container
   .bind<IOverlapEventService>(TYPES.OverlapEventService)
   .to(OverlapEventServiceImpl)
+  .inSingletonScope();
+container
+  .bind<IAutoRegisterActualService>(TYPES.AutoRegisterActualService)
+  .to(AutoRegisterActualService)
   .inSingletonScope();
 
 // ユーティリティ

--- a/src/renderer/src/pages/SettingPage.tsx
+++ b/src/renderer/src/pages/SettingPage.tsx
@@ -7,6 +7,7 @@ import { LabelList } from '@renderer/components/label/LabelList';
 import { AccountSetting } from '@renderer/components/settings/AccountSetting';
 import { ProjectList } from '@renderer/components/project/ProjectList';
 import { PomodoroTimerSetting } from '@renderer/components/settings/PomodoroSetting';
+import { ApplicationList } from '@renderer/components/application/ApplicationList';
 
 export const SettingPage = (): JSX.Element => {
   console.log('SettingPage');
@@ -25,8 +26,9 @@ export const SettingPage = (): JSX.Element => {
           <Tab label="プロジェクト" {...a11yProps(2)} />
           <Tab label="カテゴリー" {...a11yProps(3)} />
           <Tab label="ラベル" {...a11yProps(4)} />
-          <Tab label="アカウント" {...a11yProps(5)} />
-          <Tab label="ポモドーロタイマー" {...a11yProps(6)} />
+          <Tab label="アプリ" {...a11yProps(5)} />
+          <Tab label="アカウント" {...a11yProps(6)} />
+          <Tab label="ポモドーロタイマー" {...a11yProps(7)} />
         </Tabs>
       </Box>
       <CustomTabPanel value={value} index={0}>
@@ -45,9 +47,12 @@ export const SettingPage = (): JSX.Element => {
         <LabelList />
       </CustomTabPanel>
       <CustomTabPanel value={value} index={5}>
-        <AccountSetting />
+        <ApplicationList />
       </CustomTabPanel>
       <CustomTabPanel value={value} index={6}>
+        <AccountSetting />
+      </CustomTabPanel>
+      <CustomTabPanel value={value} index={7}>
         <PomodoroTimerSetting />
       </CustomTabPanel>
     </>

--- a/src/renderer/src/services/ApplicationProxyImpl.ts
+++ b/src/renderer/src/services/ApplicationProxyImpl.ts
@@ -1,0 +1,49 @@
+import { Application } from '@shared/data/Application';
+import { IApplicationProxy as IApplicationProxy } from './IApplicationProxy';
+import { injectable } from 'inversify';
+import { IpcChannel } from '@shared/constants';
+import { handleIpcOperation } from './ipcErrorHandling';
+import { Page, Pageable } from '@shared/data/Page';
+
+@injectable()
+export class ApplicationProxyImpl implements IApplicationProxy {
+  async list(pageable: Pageable): Promise<Page<Application>> {
+    return await handleIpcOperation(async () => {
+      const responce = await window.electron.ipcRenderer.invoke(
+        IpcChannel.APPLICATION_LIST,
+        pageable.toPageRequest()
+      );
+      return Page.fromPageResponse(responce);
+    });
+  }
+
+  async get(id: string): Promise<Application> {
+    return await handleIpcOperation(async () => {
+      return await window.electron.ipcRenderer.invoke(IpcChannel.APPLICATION_GET, id);
+    });
+  }
+
+  async save(application: Application): Promise<Application> {
+    return await handleIpcOperation(async () => {
+      return await window.electron.ipcRenderer.invoke(IpcChannel.APPLICATION_SAVE, application);
+    });
+  }
+
+  async delete(id: string): Promise<void> {
+    return await handleIpcOperation(async () => {
+      return await window.electron.ipcRenderer.invoke(IpcChannel.APPLICATION_DELETE, id);
+    });
+  }
+
+  async bulkDelete(ids: string[]): Promise<void> {
+    return await handleIpcOperation(async () => {
+      return await window.electron.ipcRenderer.invoke(IpcChannel.APPLICATION_BULK_DELETE, ids);
+    });
+  }
+
+  async getByName(basename: string): Promise<Application | null> {
+    return await handleIpcOperation(async () => {
+      return await window.electron.ipcRenderer.invoke(IpcChannel.APPLICATION_GET_BY_NAME, basename);
+    });
+  }
+}

--- a/src/renderer/src/services/AutoRegisterActuralService.ts
+++ b/src/renderer/src/services/AutoRegisterActuralService.ts
@@ -1,0 +1,158 @@
+import rendererContainer from './../inversify.config';
+import { ActivityEvent } from '@shared/data/ActivityEvent';
+import { EVENT_TYPE, EventEntry } from '@shared/data/EventEntry';
+import { IAutoRegisterActualService } from './IAutoRegisterActualService';
+import { injectable } from 'inversify';
+import { TYPES } from '@renderer/types';
+import { addHours } from 'date-fns';
+import { IApplicationProxy } from './IApplicationProxy';
+import { IEventEntryProxy } from './IEventEntryProxy';
+import { calculateOverlapTime } from '@shared/utils/TimeUtil';
+
+interface UsageData {
+  id: string;
+  usageTime: number;
+}
+
+@injectable()
+export class AutoRegisterActualService implements IAutoRegisterActualService {
+  async autoRegister(
+    eventEntries: EventEntry[],
+    activities: ActivityEvent[],
+    targetDate: Date,
+    userId: string
+  ): Promise<EventEntry[]> {
+    const provisionalActualPromises: Promise<EventEntry | null>[] = Array.from({ length: 24 }).map(
+      (_, hour) => {
+        const start = addHours(targetDate, hour);
+        const end = addHours(start, 1);
+        return this.createProvisionalActual(
+          userId,
+          start,
+          end,
+          eventEntries.filter((event) => event.eventType === EVENT_TYPE.PLAN),
+          eventEntries.filter((event) => event.eventType === EVENT_TYPE.ACTUAL),
+          activities
+        );
+      }
+    );
+
+    return Promise.all(provisionalActualPromises).then((actuals) =>
+      actuals.filter((actual) => actual != null)
+    );
+  }
+
+  /**
+   * 指定の時間帯に仮実績を生成する
+   *
+   * @returns 仮実績を生成しない場合はnullを返す
+   */
+  private async createProvisionalActual(
+    userId: string,
+    start: Date,
+    end: Date,
+    plans: EventEntry[],
+    actuals: EventEntry[],
+    activities: ActivityEvent[]
+  ): Promise<EventEntry | null> {
+    console.log(`仮実績の生成：${start.getHours()}:00～`);
+    const inTimeActuals = actuals.filter(
+      (actual) => calculateOverlapTime(actual.start.dateTime, actual.end.dateTime, start, end) > 0
+    );
+    if (inTimeActuals.length > 0) {
+      // 該当の時間帯に既に実績が登録されている場合は、仮実績の生成を行わない
+      console.log('実績登録済み');
+      return null;
+    }
+    const inTimeActivities = activities.filter(
+      (activity) => calculateOverlapTime(activity.start, activity.end, start, end) > 0
+    );
+    if (inTimeActivities.length === 0) {
+      // 該当の時間帯にアクティビティがない場合は、仮実績の生成を行わない
+      console.log('アクティビティなし');
+      return null;
+    }
+
+    /**
+     * アプリに紐づけられたプロジェクト別に、該当の時間帯での使用時間を計算し、最も長いプロジェクトを割り当てる
+     * カテゴリー、ラベルも同様に割り当てる
+     */
+    const applicationProxy = rendererContainer.get<IApplicationProxy>(TYPES.ApplicationProxy);
+    const usageProjectMap = new Map<string, UsageData>();
+    const usageCategoryMap = new Map<string, UsageData>();
+    const usageLabelMap = new Map<string, UsageData>();
+    for (const activity of inTimeActivities) {
+      const application = await applicationProxy.getByName(activity.basename);
+      if (application === null) {
+        continue;
+      }
+      const usageTime = calculateOverlapTime(activity.start, activity.end, start, end);
+      this.accumulateUsageTime(usageProjectMap, { id: application.relatedProjectId, usageTime });
+      this.accumulateUsageTime(usageCategoryMap, { id: application.relatedCategoryId, usageTime });
+      application.relatedLabelIds.forEach((relatedLabelId) =>
+        this.accumulateUsageTime(usageLabelMap, { id: relatedLabelId, usageTime })
+      );
+    }
+
+    const matchedProject = Array.from(usageProjectMap.values())
+      .sort((p1, p2) => {
+        return p2.usageTime - p1.usageTime;
+      })
+      .pop();
+    const matchedCategory = Array.from(usageCategoryMap.values())
+      .sort((c1, c2) => {
+        return c2.usageTime - c1.usageTime;
+      })
+      .pop();
+    // TODO: 実績にはラベルを複数貼れるので、複数取得することも考えたい
+    const matchedLabel = Array.from(usageLabelMap.values())
+      .sort((l1, l2) => {
+        return l2.usageTime - l1.usageTime;
+      })
+      .pop();
+
+    /**
+     * タイトルの自動生成
+     * 該当の時間帯に最も当てはまる予定からタイトルを取得する
+     * TODO: アクティビティから生成したいが、いい方法が思いつかなかった
+     */
+    let summary: string;
+    const inTimePlan = plans
+      .filter(
+        (plan) => calculateOverlapTime(plan.start.dateTime, plan.end.dateTime, start, end) > 0
+      )
+      .sort((p1, p2) => {
+        return (
+          calculateOverlapTime(p2.start.dateTime, p2.end.dateTime, start, end) -
+          calculateOverlapTime(p1.start.dateTime, p1.end.dateTime, start, end)
+        );
+      })
+      .pop();
+    if (inTimePlan != null) {
+      summary = inTimePlan.summary;
+    } else {
+      summary = '仮実績';
+    }
+
+    const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);
+    return eventEntryProxy
+      .create(userId, EVENT_TYPE.ACTUAL, summary, { dateTime: start }, { dateTime: end }, true)
+      .then((actual) => ({
+        ...actual,
+        projectId: matchedProject?.id,
+        categoryId: matchedCategory?.id,
+        labelIds: matchedLabel ? [matchedLabel.id] : null,
+      }));
+  }
+
+  private accumulateUsageTime(map: Map<string, UsageData>, usage: UsageData): void {
+    const preUsage = map.get(usage.id) ?? {
+      id: usage.id,
+      usageTime: 0,
+    };
+    map.set(usage.id, {
+      ...preUsage,
+      usageTime: preUsage.usageTime + usage.usageTime,
+    });
+  }
+}

--- a/src/renderer/src/services/AutoRegisterActuralService.ts
+++ b/src/renderer/src/services/AutoRegisterActuralService.ts
@@ -38,7 +38,7 @@ export class AutoRegisterActualService implements IAutoRegisterActualService {
     );
 
     return Promise.all(provisionalActualPromises).then((actuals) =>
-      actuals.filter((actual) => actual != null)
+      actuals.filter((actual): actual is EventEntry => actual != null)
     );
   }
 

--- a/src/renderer/src/services/EventEntryProxyImpl.ts
+++ b/src/renderer/src/services/EventEntryProxyImpl.ts
@@ -27,7 +27,8 @@ export class EventEntryProxyImpl implements IEventEntryProxy {
     eventType: EVENT_TYPE,
     summary: string,
     start: EventDateTime,
-    end: EventDateTime
+    end: EventDateTime,
+    isProvisional?: boolean
   ): Promise<EventEntry> {
     return await window.electron.ipcRenderer.invoke(
       IpcChannel.EVENT_ENTRY_CREATE,
@@ -35,7 +36,8 @@ export class EventEntryProxyImpl implements IEventEntryProxy {
       eventType,
       summary,
       start,
-      end
+      end,
+      isProvisional
     );
   }
 

--- a/src/renderer/src/services/IApplicationProxy.ts
+++ b/src/renderer/src/services/IApplicationProxy.ts
@@ -1,0 +1,11 @@
+import { Application } from '@shared/data/Application';
+import { Page, Pageable } from '@shared/data/Page';
+
+export interface IApplicationProxy {
+  list(pageable: Pageable): Promise<Page<Application>>;
+  get(id: string): Promise<Application>;
+  save(application: Application): Promise<Application>;
+  delete(id: string): Promise<void>;
+  bulkDelete(ids: string[]): Promise<void>;
+  getByName(basename: string): Promise<Application | null>;
+}

--- a/src/renderer/src/services/IAutoRegisterActualService.ts
+++ b/src/renderer/src/services/IAutoRegisterActualService.ts
@@ -1,0 +1,11 @@
+import { ActivityEvent } from '@shared/data/ActivityEvent';
+import { EventEntry } from '@shared/data/EventEntry';
+
+export interface IAutoRegisterActualService {
+  autoRegister(
+    eventEntries: EventEntry[],
+    activities: ActivityEvent[],
+    targetDate: Date,
+    userID: string
+  ): Promise<EventEntry[]>;
+}

--- a/src/renderer/src/services/IEventEntryProxy.ts
+++ b/src/renderer/src/services/IEventEntryProxy.ts
@@ -9,7 +9,8 @@ export interface IEventEntryProxy {
     eventType: EVENT_TYPE,
     summary: string,
     start: EventDateTime,
-    end: EventDateTime
+    end: EventDateTime,
+    isProvisional?: boolean
   ): Promise<EventEntry>;
   save(eventEntry: EventEntry): Promise<EventEntry>;
   delete(id: string): Promise<void>;

--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -23,6 +23,7 @@ export const TYPES = {
   SpeakEventSubscriber: Symbol.for('SpeakEventService'),
   NotificationSubscriber: Symbol.for('NotificationService'),
   OverlapEventService: Symbol.for('OverlapEventService'),
+  AutoRegisterActualService: Symbol.for('AutoRegisterActualService'),
 
   // shared/utils
   TimerManager: Symbol.for('TimerManager'),

--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -17,6 +17,7 @@ export const TYPES = {
   CategoryProxy: Symbol.for('CategoryProxy'),
   LabelProxy: Symbol.for('LabelProxy'),
   ProjectProxy: Symbol.for('ProjectProxy'),
+  ApplicationProxy: Symbol.for('ApplicationProxy'),
 
   // service
   SpeakEventSubscriber: Symbol.for('SpeakEventService'),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -41,6 +41,13 @@ export enum IpcChannel {
   PROJECT_DELETE = 'project_delete',
   PROJECT_BULK_DELETE = 'project_bulk_delete',
 
+  APPLICATION_LIST = 'application_list',
+  APPLICATION_GET = 'application_get',
+  APPLICATION_SAVE = 'application_save',
+  APPLICATION_DELETE = 'application_delete',
+  APPLICATION_BULK_DELETE = 'application_bulk_delete',
+  APPLICATION_GET_BY_NAME = 'application_get_by_name',
+
   CALENDAR_GET = 'calendar_get',
   CALENDAR_SYNC = 'calendar_sync',
 

--- a/src/shared/data/Application.ts
+++ b/src/shared/data/Application.ts
@@ -1,0 +1,10 @@
+export interface Application {
+  id: string;
+
+  basename: string;
+  relatedProjectId: string;
+  relatedCategoryId: string;
+  relatedLabelIds: string[];
+
+  updated: Date;
+}

--- a/src/shared/data/EventEntry.ts
+++ b/src/shared/data/EventEntry.ts
@@ -29,6 +29,7 @@ export interface EventEntry {
   projectId?: string | null;
   categoryId?: string | null;
   labelIds?: string[] | null;
+  isProvisional: boolean;
   updated: Date;
   deleted?: Date | null;
   lastSynced?: Date | null;

--- a/src/shared/data/__tests__/EventEntryFixture.ts
+++ b/src/shared/data/__tests__/EventEntryFixture.ts
@@ -12,6 +12,7 @@ export class EventEntryFixture {
       end: EventDateTimeFixture.default({ dateTime: new Date('2023-07-01T10:00:00+0900') }),
       location: null,
       description: null,
+      isProvisional: false,
       lastSynced: null,
       updated: new Date('2023-07-01T10:00:00+0900'),
       deleted: null,

--- a/src/shared/utils/TimeUtil.ts
+++ b/src/shared/utils/TimeUtil.ts
@@ -1,0 +1,19 @@
+/**
+ * 2つの時間帯が重なる時間を計算します。
+ *
+ * @returns {number} 2つの時間帯で重なった時間(ms)
+ */
+export const calculateOverlapTime = (
+  start1: Date | null | undefined,
+  end1: Date | null | undefined,
+  start2: Date | null | undefined,
+  end2: Date | null | undefined
+): number => {
+  if (!start1 || !end1 || !start2 || !end2) {
+    return 0;
+  }
+  const start = start1 > start2 ? start1 : start2;
+  const end = end1 < end2 ? end1 : end2;
+  const diffMs = end.getTime() - start.getTime();
+  return diffMs >= 0 ? diffMs : 0;
+};


### PR DESCRIPTION
## チケット
#89  

## 実装内容

* 実績の自動登録機能
  * タイムテーブルに「実績の自動登録」ボタンを追加
    * これを押すことでタイムテーブル上に仮登録状態の実績が表示される
    * 仮登録状態の実績は通常の実績のようにタイムテーブル上で編集可能(ただしDBへの保存はされない)
    * 「仮実績の本登録」ボタンを押すことでDBへ保存される
  * 設定ページに「アプリ」を追加
    * 実績の自動登録時に参照する、アプリケーションと、プロジェクト・カテゴリー・ラベルの紐づけを設定する

## 実装を見送った機能
  * アクティビティから実績のタイトルをつける
  * アクティビティのウィンドウタイトル毎に紐づけ方を設定できるようにする
  * タイムテーブルの日付を変えても仮登録の実績が保持されるようにする

  * 過去の実績とアクティビティの履歴から紐づけを自動的に設定する