### PR TITLE
feat: #170 OAuth認証をPKCEにする Google認証の対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,5 @@
 DEFAULT_MINR_SERVER_URL=http://127.0.0.1:5000
+
+# Google認証
+GOOGLE_CLIENT_ID=xxxxxxxxx
+GOOGLE_REDIRECT_URI=https://localhost/callback

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "inversify": "^6.0.1",
         "node-window-manager": "^2.2.4",
         "notistack": "^3.0.1",
+        "openid-client": "^5.7.0",
         "react-big-calendar": "^1.8.1",
         "react-color": "^2.19.3",
         "react-hook-form": "^7.45.0",
@@ -10732,6 +10733,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -11374,6 +11383,10 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/minr-desktop": {
+      "resolved": "",
+      "link": true
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -11586,6 +11599,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -11687,6 +11708,14 @@
       "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
       "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
+      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -11709,6 +11738,36 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.0.tgz",
+      "integrity": "sha512-4GCCGZt1i2kTHpwvaC/sCpTpQqDnBzDzuJcJMbH+y1Q5qI8U8RBvoSh28svarXszZHR5BAMXbJPX1PGPRE3VOA==",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/optionator": {
       "version": "0.9.3",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "inversify": "^6.0.1",
     "node-window-manager": "^2.2.4",
     "notistack": "^3.0.1",
+    "openid-client": "^5.7.0",
     "react-big-calendar": "^1.8.1",
     "react-color": "^2.19.3",
     "react-hook-form": "^7.45.0",

--- a/src/main/env.d.ts
+++ b/src/main/env.d.ts
@@ -5,3 +5,6 @@ declare namespace NodeJS {
 }
 
 declare const DEFAULT_MINR_SERVER_URL: string;
+
+declare const GOOGLE_CLIENT_ID: string;
+declare const GOOGLE_REDIRECT_URI: string;

--- a/src/main/services/GoogleAuthServiceImpl.ts
+++ b/src/main/services/GoogleAuthServiceImpl.ts
@@ -1,29 +1,34 @@
 import { BrowserWindow } from 'electron';
 import { IAuthService } from './IAuthService';
-import axios from 'axios';
 import { GoogleCredentials } from '../../shared/data/GoogleCredentials';
 import type { ICredentialsStoreService } from './ICredentialsStoreService';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../types';
 import type { IUserDetailsService } from './IUserDetailsService';
+import { BaseClient, generators, Issuer, OpenIDCallbackChecks } from 'openid-client';
+import { DateUtil } from '@shared/utils/DateUtil';
 const TOKEN_REFRESH_INTERVAL = 1000 * 60 * 5;
-
-interface GoogleCredentialsApiResponse {
-  sub: string;
-  access_token: string;
-  expiry: string;
-}
 
 @injectable()
 export class GoogleAuthServiceImpl implements IAuthService {
-  private redirectUrl = 'https://www.altus5.co.jp/callback';
   private authWindow?: BrowserWindow;
+  private _client?: BaseClient;
+
+  private authServerURL = 'https://accounts.google.com';
+  private scope = [
+    'https://www.googleapis.com/auth/userinfo.profile',
+    'https://www.googleapis.com/auth/userinfo.email',
+    'https://www.googleapis.com/auth/calendar',
+    'https://www.googleapis.com/auth/calendar.events',
+  ];
 
   constructor(
     @inject(TYPES.UserDetailsService)
     private readonly userDetailsService: IUserDetailsService,
     @inject(TYPES.GoogleCredentialsStoreService)
-    private readonly googleCredentialsService: ICredentialsStoreService<GoogleCredentials>
+    private readonly googleCredentialsService: ICredentialsStoreService<GoogleCredentials>,
+    @inject(TYPES.DateUtil)
+    private readonly dateUtil: DateUtil
   ) {}
 
   private async getUserId(): Promise<string> {
@@ -31,20 +36,27 @@ export class GoogleAuthServiceImpl implements IAuthService {
     return userDetails.userId;
   }
 
-  private get minrServerUrl(): string {
-    return process.env.MINR_SERVER_URL || DEFAULT_MINR_SERVER_URL;
+  private get clientId(): string {
+    return process.env.GOOGLE_CLIENT_ID || GOOGLE_CLIENT_ID;
+  }
+  private get redirectUri(): string {
+    return process.env.GOOGLE_REDIRECT_URI || GOOGLE_REDIRECT_URI;
   }
 
-  private get backendUrl(): string {
-    return `${this.minrServerUrl}/v1/google/auth`;
-  }
+  private async getClient(): Promise<BaseClient> {
+    if (this._client != null) {
+      return this._client;
+    }
+    const issuer = await Issuer.discover(this.authServerURL);
 
-  private get refreshTokenUrl(): string {
-    return `${this.minrServerUrl}/v1/google/refresh-token`;
-  }
+    this._client = new issuer.Client({
+      client_id: this.clientId,
+      redirect_uris: [this.redirectUri],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    });
 
-  private get revokenUrl(): string {
-    return `${this.minrServerUrl}/v1/google/revoke`;
+    return this._client;
   }
 
   async getAccessToken(): Promise<string | null> {
@@ -52,11 +64,12 @@ export class GoogleAuthServiceImpl implements IAuthService {
     const credentials = await this.googleCredentialsService.get(await this.getUserId());
     console.log({ credentials: credentials });
     if (credentials) {
-      const expiry = new Date(credentials.expiry);
-      const timedelta = expiry.getTime() - Date.now();
+      const expiry = credentials.expiry.getTime();
+      const now = this.dateUtil.getCurrentDate().getTime();
+      const timedelta = expiry - now;
       console.log({
-        now: Date.now(),
-        expiry: expiry.getTime(),
+        now: now,
+        expiry: expiry,
         timedelta: timedelta,
       });
       if (timedelta < TOKEN_REFRESH_INTERVAL) {
@@ -64,14 +77,11 @@ export class GoogleAuthServiceImpl implements IAuthService {
           timedelta: timedelta,
         });
         try {
-          const apiCredentials = await this.fetchRefreshToken(credentials.sub);
-          credentials.accessToken = apiCredentials.access_token;
-          credentials.expiry = apiCredentials.expiry;
-          await this.googleCredentialsService.save(credentials);
+          const newCredentials = await this.refreshAccessToken(credentials);
+          await this.googleCredentialsService.save(newCredentials);
         } catch (e) {
           console.log(e);
           await this.googleCredentialsService.delete(await this.getUserId());
-          await this.postRevoke(credentials.sub);
           return null;
         }
       } else {
@@ -82,35 +92,66 @@ export class GoogleAuthServiceImpl implements IAuthService {
     return null;
   }
 
-  private async getAuthUrl(): Promise<string> {
-    console.log(`fetching auth url: ${this.backendUrl}`);
-    return this.backendUrl;
+  private async getAuthUrl(checks: OpenIDCallbackChecks): Promise<string> {
+    const client = await this.getClient();
+
+    const code_challenge = checks.code_verifier
+      ? generators.codeChallenge(checks.code_verifier)
+      : undefined;
+
+    const authorizationUrl = client.authorizationUrl({
+      scope: this.scope.join(' '),
+      state: checks.state,
+      nonce: checks.nonce,
+      response_type: 'code',
+      code_challenge: code_challenge,
+      code_challenge_method: 'S256',
+      prompt: 'consent',
+    });
+
+    return authorizationUrl;
   }
 
   private async postAuthenticated(
-    code: string,
-    url: string
-  ): Promise<GoogleCredentialsApiResponse> {
-    console.log(`post url: ${this.backendUrl} url: ${url} code: ${code}`);
-    const response = await axios.post<GoogleCredentialsApiResponse>(this.backendUrl, {
-      code: code,
-      url: url,
-    });
-    return response.data;
+    url: string,
+    checks: OpenIDCallbackChecks
+  ): Promise<GoogleCredentials> {
+    const client = await this.getClient();
+    const param = client.callbackParams(url);
+    const tokenSet = await client.callback(this.redirectUri, param, checks);
+    if (!tokenSet.access_token || !tokenSet.refresh_token || !tokenSet.expires_at) {
+      throw new Error(
+        `Missing token properties in the token set. ` +
+          `access_token: ${tokenSet.access_token}, ` +
+          `refresh_token: ${tokenSet.refresh_token}, ` +
+          `expires_at: ${tokenSet.expires_at}`
+      );
+    }
+    const userInfo = await client.userinfo(tokenSet);
+    return {
+      userId: await this.getUserId(),
+      sub: userInfo.sub,
+      accessToken: tokenSet.access_token,
+      refreshToken: tokenSet.refresh_token,
+      expiry: new Date(tokenSet.expires_at),
+      updated: this.dateUtil.getCurrentDate(),
+    };
   }
 
-  private async fetchRefreshToken(sub: string): Promise<GoogleCredentialsApiResponse> {
-    console.log(`fetchRefreshToken ${this.refreshTokenUrl} sub: ${sub}`);
-    const response = await axios.post<GoogleCredentialsApiResponse>(this.refreshTokenUrl, {
-      sub: sub,
-    });
-    return response.data;
-  }
-
-  private async postRevoke(sub: string): Promise<GoogleCredentialsApiResponse> {
-    console.log(`postRevoke: ${this.revokenUrl} sub: ${sub}`);
-    const response = await axios.post<GoogleCredentialsApiResponse>(this.revokenUrl, { sub: sub });
-    return response.data;
+  private async refreshAccessToken(credentials: GoogleCredentials): Promise<GoogleCredentials> {
+    const client = await this.getClient();
+    console.log(credentials);
+    const refreshResponse = await client.refresh(credentials.refreshToken);
+    if (!refreshResponse.access_token || !refreshResponse.expires_at) {
+      throw new Error('Token refresh was failed.');
+    }
+    const newCredentials = {
+      ...credentials,
+      accessToken: refreshResponse.access_token,
+      expiry: new Date(refreshResponse.expires_at),
+    };
+    console.log(newCredentials);
+    return newCredentials;
   }
 
   async authenticate(): Promise<string> {
@@ -120,7 +161,13 @@ export class GoogleAuthServiceImpl implements IAuthService {
       return accessToken;
     }
 
-    const url = await this.getAuthUrl();
+    const checks: OpenIDCallbackChecks = {
+      state: generators.state(),
+      nonce: generators.nonce(),
+      code_verifier: generators.codeVerifier(),
+    };
+    const url = await this.getAuthUrl(checks);
+
     return new Promise((resolve, reject) => {
       this.closeAuthWindow();
 
@@ -141,21 +188,12 @@ export class GoogleAuthServiceImpl implements IAuthService {
         // this.closeAuthWindow();
         // GoogleからのリダイレクトURLから認証トークンを取り出します
         // 例えば、リダイレクトURLが "http://localhost:5000/callback?code=abcdef" の場合：
-        if (url.startsWith(this.redirectUrl)) {
+        if (url.startsWith(this.redirectUri)) {
           event.preventDefault();
           const urlObj = new URL(url);
           const token = urlObj.searchParams.get('code');
           if (token) {
-            console.log(`call postAuthenticated`);
-            const apiCredentials = await this.postAuthenticated(token, url);
-            console.log(`result postAuthenticated`, apiCredentials);
-            const credentials: GoogleCredentials = {
-              userId: await this.getUserId(),
-              sub: apiCredentials.sub,
-              accessToken: apiCredentials.access_token,
-              expiry: apiCredentials.expiry,
-              updated: new Date(),
-            };
+            const credentials = await this.postAuthenticated(url, checks);
             await this.googleCredentialsService.save(credentials);
             resolve(token);
           } else {
@@ -173,10 +211,10 @@ export class GoogleAuthServiceImpl implements IAuthService {
   }
 
   async revoke(): Promise<void> {
-    const credentials = await this.googleCredentialsService.get(await this.getUserId());
+    const userId = await this.getUserId();
+    const credentials = await this.googleCredentialsService.get(userId);
     if (credentials) {
-      await this.googleCredentialsService.delete(await this.getUserId());
-      await this.postRevoke(credentials.sub);
+      await this.googleCredentialsService.delete(userId);
     }
   }
 

--- a/src/shared/data/GoogleCredentials.ts
+++ b/src/shared/data/GoogleCredentials.ts
@@ -3,7 +3,8 @@ export interface GoogleCredentials {
 
   sub: string;
   accessToken: string;
-  expiry: string;
+  refreshToken: string;
+  expiry: Date;
 
   updated: Date;
 }


### PR DESCRIPTION
## チケット
#170 

## 実装内容
- server側にあった認証処理をdesktopへ移動(Googleのみ)
- PKCEによる認証の実装(Googleのみ)
  - OAuth認証の実装方法としては以下を参考にした。
  - https://zenn.dev/takamichie/articles/eab17c90922872