### PR TITLE
fix: #188 テスト時にloggerでgetPathを呼び出すとエラーになる

### DIFF
--- a/jest.config.node.js
+++ b/jest.config.node.js
@@ -15,6 +15,7 @@ module.exports = {
   moduleNameMapper: {
     '^@main/(.*)$': '<rootDir>/src/main/$1',
     '^@shared/(.*)$': '<rootDir>/src/shared/$1',
+    '^electron$': '<rootDir>/src/__tests__/jest.electron.ts',
   },
   setupFiles: ['<rootDir>/src/main/inversify.config.ts'],
 };

--- a/src/__tests__/jest.electron.ts
+++ b/src/__tests__/jest.electron.ts
@@ -1,0 +1,5 @@
+import path from "path";
+
+export const app = {
+  getPath: jest.fn().mockReturnValue(path.join(process.cwd(), '.test')),
+};

--- a/src/__tests__/jest.electron.ts
+++ b/src/__tests__/jest.electron.ts
@@ -1,5 +1,7 @@
-import path from "path";
+import path from 'path';
 
+// テスト実行時にelectronのライブラリを使用すると認識されずエラーになってしまうため、モック化する。
+// * electronのメソッドを新たにモック化する場合はappに追加する。
 export const app = {
   getPath: jest.fn().mockReturnValue(path.join(process.cwd(), '.test')),
 };

--- a/src/main/services/WinstonLoggerImpl.ts
+++ b/src/main/services/WinstonLoggerImpl.ts
@@ -13,14 +13,9 @@ export class WinstonLoggerImpl implements ILogger {
   private loggerName = '';
 
   constructor() {
-    let logFilePath: string;
-    if (process.versions.electron) {
-      const userDataPath = app.getPath('userData');
-      const baseDir = app.isPackaged ? 'log' : 'log-dev';
-      logFilePath = path.join(userDataPath, baseDir);
-    } else {
-      logFilePath = path.join(process.cwd(), 'log');
-    }
+    const userDataPath = app.getPath('userData');
+    const baseDir = app.isPackaged ? 'log' : 'log-dev';
+    const logFilePath = path.join(userDataPath, baseDir);
     this.logger = winston.createLogger({
       level: process.env.LOG_LEVEL?.toLowerCase() || 'info',
       format: winston.format.combine(

--- a/src/main/services/WinstonLoggerImpl.ts
+++ b/src/main/services/WinstonLoggerImpl.ts
@@ -14,13 +14,12 @@ export class WinstonLoggerImpl implements ILogger {
 
   constructor() {
     let logFilePath: string;
-    try {
+    if (process.versions.electron) {
       const userDataPath = app.getPath('userData');
       const baseDir = app.isPackaged ? 'log' : 'log-dev';
       logFilePath = path.join(userDataPath, baseDir);
-    } catch (error) {
-      console.log('logFilePath create failed:', error);
-      logFilePath = './log';
+    } else {
+      logFilePath = path.join(process.cwd(), 'log');
     }
     this.logger = winston.createLogger({
       level: process.env.LOG_LEVEL?.toLowerCase() || 'info',

--- a/src/main/services/__tests__/ActivityServiceImpl.test.ts
+++ b/src/main/services/__tests__/ActivityServiceImpl.test.ts
@@ -11,6 +11,9 @@ import { IWindowLogService } from '../IWindowLogService';
 import { SYSTEM_IDLE_PID } from '@shared/data/WindowLog';
 import { ActivityColorServiceMockBuilder } from './__mocks__/ActivityColorServiceMockBuilder';
 import { IActivityColorService } from '../IActivityColorService';
+import { getLogger } from '@main/utils/LoggerUtil';
+
+const logger = getLogger('ActivityServiceImpl.test');
 
 describe('ActivityServiceImpl', () => {
   let service: IActivityService;
@@ -303,7 +306,7 @@ describe('ActivityServiceImpl', () => {
 
         const dummy = new Date();
         if (testCase.description === '異なるbasenameを持つWindowLogは別々のActivityEventになる') {
-          console.log(testCase.description);
+          if (logger.isDebugEnabled()) logger.debug(testCase.description);
         }
         const events = await service.fetchActivities(dummy, dummy);
         expect(events.length).toEqual(testCase.expected.length);

--- a/src/main/services/__tests__/ActivityServiceImpl.test.ts
+++ b/src/main/services/__tests__/ActivityServiceImpl.test.ts
@@ -11,9 +11,6 @@ import { IWindowLogService } from '../IWindowLogService';
 import { SYSTEM_IDLE_PID } from '@shared/data/WindowLog';
 import { ActivityColorServiceMockBuilder } from './__mocks__/ActivityColorServiceMockBuilder';
 import { IActivityColorService } from '../IActivityColorService';
-import { getLogger } from '@main/utils/LoggerUtil';
-
-const logger = getLogger('ActivityServiceImpl.test');
 
 describe('ActivityServiceImpl', () => {
   let service: IActivityService;
@@ -305,9 +302,6 @@ describe('ActivityServiceImpl', () => {
         jest.spyOn(windowLogService, 'list').mockResolvedValueOnce(testCase.winlogs);
 
         const dummy = new Date();
-        if (testCase.description === '異なるbasenameを持つWindowLogは別々のActivityEventになる') {
-          logger.debug(testCase.description);
-        }
         const events = await service.fetchActivities(dummy, dummy);
         expect(events.length).toEqual(testCase.expected.length);
 

--- a/src/main/services/__tests__/ActivityServiceImpl.test.ts
+++ b/src/main/services/__tests__/ActivityServiceImpl.test.ts
@@ -306,7 +306,7 @@ describe('ActivityServiceImpl', () => {
 
         const dummy = new Date();
         if (testCase.description === '異なるbasenameを持つWindowLogは別々のActivityEventになる') {
-          if (logger.isDebugEnabled()) logger.debug(testCase.description);
+          logger.debug(testCase.description);
         }
         const events = await service.fetchActivities(dummy, dummy);
         expect(events.length).toEqual(testCase.expected.length);

--- a/src/main/services/__tests__/ActivityUsageServiceImpl.test.ts
+++ b/src/main/services/__tests__/ActivityUsageServiceImpl.test.ts
@@ -172,8 +172,10 @@ describe('ActivityUsageServiceImpl', () => {
 
         const activityUsage = await service.get(startDate, endDate);
 
-        for (const act of activityUsage) {
-          if (logger.isDebugEnabled()) logger.debug(act.basename + '/' + act.usageTime);
+        if (logger.isDebugEnabled()) {
+          for (const act of activityUsage) {
+            logger.debug(act.basename + '/' + act.usageTime);
+          }
         }
         expect(activityUsage.length).toEqual(testCase.expected.length);
         expect(activityUsage).toEqual(testCase.expected.map((e) => expect.objectContaining(e)));

--- a/src/main/services/__tests__/ActivityUsageServiceImpl.test.ts
+++ b/src/main/services/__tests__/ActivityUsageServiceImpl.test.ts
@@ -4,8 +4,11 @@ import { ActivityServiceMockBuilder } from './__mocks__/ActivityServiceMockBuild
 import { ActivityUsageServiceImpl } from '../ActicityUsageServiceImpl';
 import { IActivityUsageService } from '../IActivityUsageService';
 import { ActivityUsageFixture } from '@shared/data/__tests__/ActivityUsageFixture';
+import { getLogger } from '@main/utils/LoggerUtil';
 
-describe('ActivityServiceImpl', () => {
+const logger = getLogger('ActivityUsageServiceImpl.test');
+
+describe('ActivityUsageServiceImpl', () => {
   let service: IActivityUsageService;
   let activityService: IActivityService;
 
@@ -170,7 +173,7 @@ describe('ActivityServiceImpl', () => {
         const activityUsage = await service.get(startDate, endDate);
 
         for (const act of activityUsage) {
-          console.log(act.basename + '/' + act.usageTime);
+          if (logger.isDebugEnabled()) logger.debug(act.basename + '/' + act.usageTime);
         }
         expect(activityUsage.length).toEqual(testCase.expected.length);
         expect(activityUsage).toEqual(testCase.expected.map((e) => expect.objectContaining(e)));

--- a/src/main/services/__tests__/CalendarSynchronizerImpl.test.ts
+++ b/src/main/services/__tests__/CalendarSynchronizerImpl.test.ts
@@ -20,6 +20,9 @@ import { CalendarSetting } from '@shared/data/CalendarSetting';
 import { CalendarSettingFixture } from '@shared/data/__tests__/CalendarSettingFixture';
 import { IpcService } from '../IpcService';
 import { TYPES } from '@main/types';
+import { getLogger } from '@main/utils/LoggerUtil';
+
+const logger = getLogger('CalendarSynchronizerImpl.test');
 
 describe('CalendarSynchronizerImpl', () => {
   let synchronizer: CalendarSyncProcessorImpl;
@@ -264,7 +267,8 @@ describe('CalendarSynchronizerImpl', () => {
 
       // メソッドの呼び出しが期待通りかを確認
       if (t.expectedInsertMinrEvent) {
-        console.log('expectedInsertMinrEvent', t.expectedInsertMinrEvent);
+        if (logger.isDebugEnabled())
+          logger.debug('expectedInsertMinrEvent', t.expectedInsertMinrEvent);
         expect(eventEntryService.save).toHaveBeenCalledWith(
           expect.objectContaining({
             externalEventEntryId: t.expectedInsertMinrEvent.externalEventEntryId,

--- a/src/main/services/__tests__/TestDataSource.ts
+++ b/src/main/services/__tests__/TestDataSource.ts
@@ -1,18 +1,21 @@
+import { getLogger } from '@main/utils/LoggerUtil';
 import { DataSource } from '../DataSource';
 import * as fs from 'fs';
 import { injectable } from 'inversify';
 import * as path from 'path';
 
+const logger = getLogger('TestDataSource');
+
 @injectable()
 export class TestDataSource<T> extends DataSource<T> {
   getPath(dbname: string): string {
-    console.log('process.cwd', process.cwd());
+    if (logger.isDebugEnabled()) logger.debug('process.cwd', process.cwd());
     const userDataPath = path.join(process.cwd(), '.test');
     if (!fs.existsSync(userDataPath)) {
       fs.mkdirSync(userDataPath, { recursive: true });
     }
     const filepath = path.join(userDataPath, dbname);
-    console.log(`db ${dbname} path: ${filepath}`);
+    if (logger.isDebugEnabled()) logger.debug(`db ${dbname} path: ${filepath}`);
     return filepath;
   }
 }


### PR DESCRIPTION
## チケット

#188 

## 概要

ユニットテストを実行した際に、`getPath`のライブラリが認識できず、ログ出力のパス作成でエラーが出力されている不具合を確認したので、エラーが出力されないように修正を行う。

## getPathを呼び出すとエラーになる課題の対応方法について

* Context
    *  今回のエラーは、`electron` のライブラリが認識されていない状態で呼び出されることが原因。
    * `jest` では `electron` は通常動作しないことからエラーが発生していると考えられる。

* Decision
    * `getPath`のライブラリが認識できない場合は、`process.cwd()`でログ出力のパスを作成する。

* Consequences
    * ユニットテストにおいて、動作しないなどのモジュールはモック化するのが一般的だが、ロガーによるログ出力をテストでも活用することを想定しているため、モック化はできない。
        * ロガーの本来の機能を維持したまま、`getPath`でエラーが発生しないように修正する必要がある。
    * `getPath`のエラーは`electron`ライブラリを認識できないことから発生しているため、 `process.versions.electron`で`electron`の状態を確認することでエラーがでるか判定することができる、
    * `process.versions.electron`で`electron`ライブラリが使用できない場合は、現在の作業ディレクトリを返す`process.cwd()`を使用しログが出力されるようにすることでエラーなくログ出力を行える。

## ユニットテストのログ出力の修正について

* Context
    * 現在のユニットテストは、`console.log`を使用しており記録に残らない課題がある。
    * 今回のエラー対応と合わせて、試験的にユニットテストのログをログファイルに出力する。

* Decision
    * ユニットテストのconsole.logをlogger.debugに置き換え。

* Consequences
    * ユニットテストを実行するのは、アプリの開発を行うときであると考えられる。
    * `WinstonLogger`ではロガー名を設定することができるため、テスト用のログディレクトリを切らなくても、ロガー名で検索すればログを確認することができる。
    * 以上のことから、テスト用のログディレクトリを作成せず、`process.cwd()`で作成するログディレクトリに出力されることを想定し、既存の`console.log`を置き換える対応のみを行う。