### PR TITLE
fix: #177 Releaseがmac用のバイナリだけになっている

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ LOG_LEVEL=debug
 
 # Google認証
 GOOGLE_CLIENT_ID=xxxxxxxxx
-GOOGLE_REDIRECT_URI=https://localhost/callback
+GOOGLE_REDIRECT_URI=http://127.0.0.1/callback
 
 # GitHub認証
 GITHUB_CLIENT_ID=xxxxxxxxx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ env:
   GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
   GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
   APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-  APPLE_API_KEY_ID: ${{ secret.APPLE_API_KEY_ID }}
-  APPLE_API_ISSUER: ${{ secret.APPLE_API_ISSUER }}
+  APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+  APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          path: /artifacts
+          path: artifacts
 
       - name: Create GitHub Release and Upload Build
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
           MAC_CSC_PASSWORD: ${{ secrets.MAC_CSC_PASSWORD }}
         run: |
-          echo "CSC_LINK=${MAC_CSC_LINK}" >> $GITHUB_ENV
+          echo "CSC_LINK=$(${MAC_CSC_LINK} | tr -d '\n')" >> $GITHUB_ENV
           echo "CSC_KEY_PASSWORD=${MAC_CSC_PASSWORD}" >> $GITHUB_ENV
         shell: bash
 
@@ -138,7 +138,7 @@ jobs:
           WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
           WINDOWS_CSC_PASSWORD: ${{ secrets.WINDOWS_CSC_PASSWORD }}
         run: |
-          echo "CSC_LINK=${WINDOWS_CSC_LINK}" >> $GITHUB_ENV
+          echo "CSC_LINK=$(${WINDOWS_CSC_LINK} | tr -d '\n')" >> $GITHUB_ENV
           echo "CSC_KEY_PASSWORD=${WINDOWS_CSC_PASSWORD}" >> $GITHUB_ENV
         shell: bash
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,6 @@ env:
   GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
   GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
   GITHUB_CLIENT_ID: ${{ secrets.APP_GITHUB_CLIENT_ID }}
-  MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
-  MAC_CSC_PASSWORD: ${{ secrets.MAC_CSC_PASSWORD }}
-  WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
-  WINDOWS_CSC_PASSWORD: ${{ secrets.WINDOWS_CSC_PASSWORD }}
   APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
   APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
   APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
@@ -67,20 +63,14 @@ jobs:
             platform: mac
             architecture: x64
             ext: dmg
-            csc_link: ${{ env.MAC_CSC_LINK }}
-            csc_key_password: ${{ env.MAC_CSC_PASSWORD }}
           - os: macos-14
             platform: mac
             architecture: arm64
             ext: dmg
-            csc_link: ${{ env.MAC_CSC_LINK }}
-            csc_key_password: ${{ env.MAC_CSC_PASSWORD }}
           - os: windows-latest
             platform: win
             architecture: x64
             ext: exe
-            csc_link: ${{ env.WINDOWS_CSC_LINK }}
-            csc_key_password: ${{ env.WINDOWS_CSC_PASSWORD }}
           - os: ubuntu-latest
             platform: linux
             architecture: x64
@@ -132,10 +122,28 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: set CSC for Mac
+        if: startsWith(matrix.os,'macos')
+        env:
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_PASSWORD: ${{ secrets.MAC_CSC_PASSWORD }}
+        run: |
+          echo "CSC_LINK=${MAC_CSC_LINK}" >> $GITHUB_ENV
+          echo "CSC_KEY_PASSWORD=${MAC_CSC_PASSWORD}" >> $GITHUB_ENV
+        shell: bash
+
+      - name: set CSC for Windows
+        if: startsWith(matrix.os,'windows')
+        env:
+          WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+          WINDOWS_CSC_PASSWORD: ${{ secrets.WINDOWS_CSC_PASSWORD }}
+        run: |
+          echo "CSC_LINK=${WINDOWS_CSC_LINK}" >> $GITHUB_ENV
+          echo "CSC_KEY_PASSWORD=${WINDOWS_CSC_PASSWORD}" >> $GITHUB_ENV
+        shell: bash
+
       - name: Build Electron App
         env:
-          CSC_LINK: ${{ matrix.csc_link }}
-          CSC_KEY_PASSWORD: ${{ matrix.csc_key_password }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
         run: npm run build:${{ matrix.platform }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,12 +122,29 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+          DEBUG: electron-osx-sign*
         run: npm run build:${{ matrix.platform }}
 
       - name: delete Apple API Key File
         if: startsWith(matrix.os,'macos')
         run: rm -f ${{ env.APPLE_API_KEY_PATH }}
         shell: bash
+
+      - name: Verify DMG Signing
+        if: startsWith(matrix.os,'macos')
+        run: codesign --verify --deep --strict dist/minr-desktop-*.dmg || echo "DMG signing failed."
+
+      - name: Verify App Signing Inside DMG
+        if: startsWith(matrix.os,'macos')
+        run: |
+          hdiutil attach dist/minr-desktop-*.dmg
+          codesign --verify --deep --strict /Volumes/minr-desktop/minr-desktop.app || echo "App signing inside DMG failed."
+          hdiutil detach /Volumes/minr-desktop
+
+      - name: Verify Notarization
+        if: startsWith(matrix.os,'macos')
+        run: xcrun stapler validate dist/minr-desktop-*.dmg || echo "Notarization validation failed."
 
       - name: Get version from package.json
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,19 +45,15 @@ jobs:
         include:
           - os: macos-13
             platform: mac
-            architecture: x64
             ext: dmg
           - os: macos-14
             platform: mac
-            architecture: arm64
             ext: dmg
           - os: windows-2022
             platform: win
-            architecture: x64
             ext: exe
           - os: ubuntu-24.04
             platform: linux
-            architecture: x64
             ext: AppImage
 
     steps:
@@ -141,7 +137,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}
-          path: ./dist/minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}-${{ matrix.architecture }}.${{ matrix.ext }}
+          path: ./dist/minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}-*.${{ matrix.ext }}
 
   release:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
           MAC_CSC_PASSWORD: ${{ secrets.MAC_CSC_PASSWORD }}
         run: |
-          echo "CSC_LINK=$(${MAC_CSC_LINK} | tr -d '\n')" >> $GITHUB_ENV
+          echo "CSC_LINK=$(echo ${MAC_CSC_LINK} | tr -d '\n')" >> $GITHUB_ENV
           echo "CSC_KEY_PASSWORD=${MAC_CSC_PASSWORD}" >> $GITHUB_ENV
         shell: bash
 
@@ -138,7 +138,7 @@ jobs:
           WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
           WINDOWS_CSC_PASSWORD: ${{ secrets.WINDOWS_CSC_PASSWORD }}
         run: |
-          echo "CSC_LINK=$(${WINDOWS_CSC_LINK} | tr -d '\n')" >> $GITHUB_ENV
+          echo "CSC_LINK=$(echo ${WINDOWS_CSC_LINK} | tr -d '\n')" >> $GITHUB_ENV
           echo "CSC_KEY_PASSWORD=${WINDOWS_CSC_PASSWORD}" >> $GITHUB_ENV
         shell: bash
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   create-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
 
@@ -56,7 +56,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-13, macos-14, windows-latest, ubuntu-latest]
+        os: [macos-13, macos-14, windows-2022, ubuntu-24.04]
         node-version: [18.x]
         include:
           - os: macos-13
@@ -67,11 +67,11 @@ jobs:
             platform: mac
             architecture: arm64
             ext: dmg
-          - os: windows-latest
+          - os: windows-2022
             platform: win
             architecture: x64
             ext: exe
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             platform: linux
             architecture: x64
             ext: AppImage
@@ -146,14 +146,18 @@ jobs:
       - name: Build Electron App
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
-        run: npm run build:${{ matrix.platform }}
+          DEBUG: electron-builder
+        run: |
+          echo ${#CSC_LINK}
+          echo ${#CSC_KEY_PASSWORD}
+          echo ${#APPLE_API_KEY}
+          echo ${#APPLE_API_KEY_ID}
+          echo ${#APPLE_API_ISSUER}
+          npm run build:${{ matrix.platform }}
 
       - name: Get version from package.json
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
         shell: bash
-
-      - name: check directory
-        run: ls -R ./dist
 
       - name: Create GitHub Release and Upload Build
         uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,17 +41,6 @@ jobs:
             exit 1
           fi
 
-      - name: Check environment exists
-        env:
-          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
-          MAC_CSC_PASSWORD: ${{ secrets.MAC_CSC_PASSWORD }}
-        run: |
-          echo ${#GOOGLE_CLIENT_ID}
-          echo ${#GITHUB_CLIENT_ID}
-          echo ${#MAC_CSC_LINK}
-          echo ${#MAC_CSC_PASSWORD}
-        shell: bash
-
       - name: Create release
         id: create_release
         uses: actions/create-release@v1.0.1
@@ -156,7 +145,10 @@ jobs:
       - name: Build Electron App
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
-        run: npm run build:${{ matrix.platform }}
+        run: |
+          echo ${#CSC_LINK}
+          echo ${#CSC_KEY_PASSWORD} 
+          npm run build:${{ matrix.platform }}
 
       - name: Get version from package.json
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,10 +116,6 @@ jobs:
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
         shell: bash
 
-      # デバッグ用に追加
-      - name: check files exist
-        run: ls ./dist
-
       - name: Create GitHub Release and Upload Build
         uses: actions/upload-release-asset@v1.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 env:
   GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
   GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
-  GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
+  GITHUB_CLIENT_ID: ${{ secrets.APP_GITHUB_CLIENT_ID }}
   APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
   APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
   APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
@@ -63,14 +63,20 @@ jobs:
             platform: mac
             architecture: x64
             ext: dmg
+            csc_link: ${{ secrets.MAC_CSC_LINK }}
+            csc_key_password: ${{ secrets.MAC_CSC_PASSWORD }}
           - os: macos-14
             platform: mac
             architecture: arm64
             ext: dmg
+            csc_link: ${{ secrets.MAC_CSC_LINK }}
+            csc_key_password: ${{ secrets.MAC_CSC_PASSWORD }}
           - os: windows-latest
             platform: win
             architecture: x64
             ext: exe
+            csc_link: ${{ secrets.WINDOWS_CSC_LINK }}
+            csc_key_password: ${{ secrets.WINDOWS_CSC_PASSWORD }}
           - os: ubuntu-latest
             platform: linux
             architecture: x64
@@ -123,6 +129,10 @@ jobs:
         run: npm install
 
       - name: Build Electron App
+        env:
+          CSC_LINK: ${{ matrix.csc_link }}
+          CSC_KEY_PASSWORD: ${{ matrix.csc_key_password }}
+          CSC_IDENTITY_AUTO_DISCOVERY: false
         run: npm run build:${{ matrix.platform }}
 
       - name: Get version from package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,8 +124,6 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-
-          DEBUG: electron-osx-sign*
         run: npm run build:${{ matrix.platform }}
 
       - name: Get version from package.json
@@ -136,12 +134,12 @@ jobs:
         if: startsWith(matrix.os,'macos')
         run: codesign --verify --deep --strict dist/minr-desktop-*.dmg || echo "DMG signing failed."
 
-      - name: Verify App Signing Inside DMG
-        if: startsWith(matrix.os,'macos')
-        run: |
-          hdiutil attach dist/minr-desktop-*.dmg
-          codesign --verify --deep --strict "/Volumes/minr-desktop ${{ env.PACKAGE_VERSION }}-${{ matrix.arch }}/minr-desktop.app" || echo "App signing inside DMG failed."
-          hdiutil detach /Volumes/minr-desktop
+      # - name: Verify App Signing Inside DMG
+      #   if: startsWith(matrix.os,'macos')
+      #   run: |
+      #     hdiutil attach dist/minr-desktop-*.dmg
+      #     codesign --verify --deep --strict "/Volumes/minr-desktop ${{ env.PACKAGE_VERSION }}-${{ matrix.arch }}/minr-desktop.app" || echo "App signing inside DMG failed."
+      #     hdiutil detach /Volumes/minr-desktop
 
       - name: Verify Notarization
         if: startsWith(matrix.os,'macos')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
           MAC_CSC_PASSWORD: ${{ secrets.MAC_CSC_PASSWORD }}
         run: |
-          echo "CSC_LINK=$(echo ${MAC_CSC_LINK} | tr -d '\n')" >> $GITHUB_ENV
+          echo "CSC_LINK=${MAC_CSC_LINK}" >> $GITHUB_ENV
           echo "CSC_KEY_PASSWORD=${MAC_CSC_PASSWORD}" >> $GITHUB_ENV
         shell: bash
 
@@ -138,7 +138,7 @@ jobs:
           WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
           WINDOWS_CSC_PASSWORD: ${{ secrets.WINDOWS_CSC_PASSWORD }}
         run: |
-          echo "CSC_LINK=$(echo ${WINDOWS_CSC_LINK} | tr -d '\n')" >> $GITHUB_ENV
+          echo "CSC_LINK=${WINDOWS_CSC_LINK}" >> $GITHUB_ENV
           echo "CSC_KEY_PASSWORD=${WINDOWS_CSC_PASSWORD}" >> $GITHUB_ENV
         shell: bash
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,9 @@ jobs:
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
         shell: bash
 
+      - name: check directory
+        run: ls -R ./dist
+
       - name: Create GitHub Release and Upload Build
         uses: actions/upload-release-asset@v1.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ env:
   GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
   GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
   GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
+  APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+  APPLE_API_KEY_ID: ${{ secret.APPLE_API_KEY_ID }}
+  APPLE_API_ISSUER: ${{ secret.APPLE_API_ISSUER }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -53,17 +56,24 @@ jobs:
 
     strategy:
       matrix:
-        os: [macOS-latest, windows-latest, ubuntu-latest]
+        os: [macos-13, macos-14, windows-latest, ubuntu-latest]
         node-version: [18.x]
         include:
-          - os: macos-latest
+          - os: macos-13
             platform: mac
+            architecture: x64
+            ext: dmg
+          - os: macos-14
+            platform: mac
+            architecture: arm64
             ext: dmg
           - os: windows-latest
             platform: win
+            architecture: x64
             ext: exe
           - os: ubuntu-latest
             platform: linux
+            architecture: x64
             ext: AppImage
 
     steps:
@@ -127,5 +137,5 @@ jobs:
         with:
           upload_url: ${{ needs.create-release.outputs.upload_url }}
           asset_path: ./dist/minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}.${{ matrix.ext }}
-          asset_name: minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}.${{ matrix.ext }}
+          asset_name: minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}-${{ matrix.architecture }}.${{ matrix.ext }}
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,7 @@ on:
       - '*'
 
 env:
-  GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-  GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
-  GITHUB_CLIENT_ID: ${{ secrets.APP_GITHUB_CLIENT_ID }}
-  APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-  APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-  APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+  APPLE_API_KEY_PATH: ./minr-api-key.p8
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -122,31 +117,32 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: set CSC for Mac
+      - name: create Apple API Key File
         if: startsWith(matrix.os,'macos')
-        env:
-          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
-          MAC_CSC_PASSWORD: ${{ secrets.MAC_CSC_PASSWORD }}
-        run: |
-          echo "CSC_LINK=${MAC_CSC_LINK}" >> $GITHUB_ENV
-          echo "CSC_KEY_PASSWORD=${MAC_CSC_PASSWORD}" >> $GITHUB_ENV
+        run: echo "${{ secrets.APPLE_API_KEY }}" > "${{ env.APPLE_API_KEY_PATH }}"
         shell: bash
-
-      # windowsのコード署名証明書をsecretsに入れるまでコメントアウト
-      # - name: set CSC for Windows
-      #   if: startsWith(matrix.os,'windows')
-      #   env:
-      #     WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
-      #     WINDOWS_CSC_PASSWORD: ${{ secrets.WINDOWS_CSC_PASSWORD }}
-      #   run: |
-      #     echo "CSC_LINK=${WINDOWS_CSC_LINK}" >> $GITHUB_ENV
-      #     echo "CSC_KEY_PASSWORD=${WINDOWS_CSC_PASSWORD}" >> $GITHUB_ENV
-      #   shell: bash
 
       - name: Build Electron App
         env:
-          DEBUG: electron-notarize*
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
+          GITHUB_CLIENT_ID: ${{ secrets.APP_GITHUB_CLIENT_ID }}
+
+          CSC_LINK: ${{ secrets.MAC_CSC_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          # GitHubのSecretsに登録するまでコメントアウト
+          # WIN_CSC_LINK: ${{ secrets.WIN_CSC_BASE64 }}
+          # WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+
+          APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: npm run build:${{ matrix.platform }}
+
+      - name: delete Apple API Key File
+        if: startsWith(matrix.os,'macos')
+        run: rm -f ${{ env.APPLE_API_KEY_PATH }}
+        shell: bash
 
       - name: Get version from package.json
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,28 +126,13 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: npm run build:${{ matrix.platform }}
 
-      - name: Get version from package.json
-        run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Verify DMG Signing
-        if: startsWith(matrix.os,'macos')
-        run: codesign --verify --deep --strict dist/minr-desktop-*.dmg || echo "DMG signing failed."
-
-      # - name: Verify App Signing Inside DMG
-      #   if: startsWith(matrix.os,'macos')
-      #   run: |
-      #     hdiutil attach dist/minr-desktop-*.dmg
-      #     codesign --verify --deep --strict "/Volumes/minr-desktop ${{ env.PACKAGE_VERSION }}-${{ matrix.arch }}/minr-desktop.app" || echo "App signing inside DMG failed."
-      #     hdiutil detach /Volumes/minr-desktop
-
-      - name: Verify Notarization
-        if: startsWith(matrix.os,'macos')
-        run: xcrun stapler validate dist/minr-desktop-*.dmg || echo "Notarization validation failed."
-
       - name: delete Apple API Key File
         if: startsWith(matrix.os,'macos')
         run: rm -f ${{ env.APPLE_API_KEY_PATH }}
+        shell: bash
+
+      - name: Get version from package.json
+        run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
         shell: bash
 
       - name: Upload Artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,8 +145,7 @@ jobs:
 
       - name: Build Electron App
         env:
-          # CSC_IDENTITY_AUTO_DISCOVERY: false
-          DEBUG: electron-builder
+          DEBUG: electron-notarize*
         run: npm run build:${{ matrix.platform }}
 
       - name: Get version from package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Create GitHub Release and Upload Build
         uses: actions/upload-release-asset@v1.0.1
         with:
-          upload_url: ${{ env.upload_url }}
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
           asset_path: ./dist/minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}.${{ matrix.ext }}
           asset_name: minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}.${{ matrix.ext }}
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ env:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
 
     steps:
       - name: Check out code
@@ -44,9 +46,6 @@ jobs:
           release_name: Release ${{ env.PACKAGE_VERSION }}
           draft: false
           prerelease: false
-
-      - name: Set upload_url output
-        run: echo "upload_url=${{ steps.create_release.outputs.upload_url }}" >> $GITHUB_OUTPUT
 
   release:
     needs: create-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,10 @@ jobs:
         run: rm -f ${{ env.APPLE_API_KEY_PATH }}
         shell: bash
 
+      - name: Get version from package.json
+        run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+        shell: bash
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,8 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+          DEBUG: electron-notarize*
         run: npm run build:${{ matrix.platform }}
 
       - name: delete Apple API Key File

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,15 +145,9 @@ jobs:
 
       - name: Build Electron App
         env:
-          CSC_IDENTITY_AUTO_DISCOVERY: false
+          # CSC_IDENTITY_AUTO_DISCOVERY: false
           DEBUG: electron-builder
-        run: |
-          echo ${#CSC_LINK}
-          echo ${#CSC_KEY_PASSWORD}
-          echo ${#APPLE_API_KEY}
-          echo ${#APPLE_API_KEY_ID}
-          echo ${#APPLE_API_ISSUER}
-          npm run build:${{ matrix.platform }}
+        run: npm run build:${{ matrix.platform }}
 
       - name: Get version from package.json
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,7 @@ jobs:
       - name: Build Electron App
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          DEBUG: electron-builder
         run: |
           echo ${#CSC_LINK}
           echo ${#CSC_KEY_PASSWORD} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,18 +40,18 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2022, macos-13, macos-14, ubuntu-24.04]
+        os: [windows-2022] # macos-13, macos-14, ubuntu-24.04
         node-version: [18.x]
         include:
           # Mac版は署名がうまくいっていないため保留
-          - os: macos-13
-            platform: mac
-            ext: dmg
-            arch: x64
-          - os: macos-14
-            platform: mac
-            ext: dmg
-            arch: arm64
+          # - os: macos-13
+          #   platform: mac
+          #   ext: dmg
+          #   arch: x64
+          # - os: macos-14
+          #   platform: mac
+          #   ext: dmg
+          #   arch: arm64
           - os: windows-2022
             platform: win
             ext: exe
@@ -111,6 +111,7 @@ jobs:
         run: echo "${{ secrets.APPLE_API_KEY }}" > "${{ env.APPLE_API_KEY_PATH }}"
         shell: bash
 
+      # 公証プロセスで失敗した場合、Re-run jobsでもう一度やると成功することがある
       - name: Build Electron App
         env:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
@@ -155,6 +156,6 @@ jobs:
 
       - name: Create GitHub Release and Upload Build
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
         with:
+          name: Release ${{ github.ref_name }}
           files: artifacts/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}
-          path: ./dist/minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}.${{ matrix.ext }}
+          path: ./dist/minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}-${{ matrix.architecture }}.${{ matrix.ext }}
 
   release:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,11 @@ jobs:
           - os: macos-13
             platform: mac
             ext: dmg
+            arch: x64
           - os: macos-14
             platform: mac
             ext: dmg
+            arch: arm64
           - os: windows-2022
             platform: win
             ext: exe
@@ -139,7 +141,7 @@ jobs:
         if: startsWith(matrix.os,'macos')
         run: |
           hdiutil attach dist/minr-desktop-*.dmg
-          codesign --verify --deep --strict /Volumes/minr-desktop/minr-desktop.app || echo "App signing inside DMG failed."
+          codesign --verify --deep --strict "/Volumes/minr-desktop ${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}-${{ matrix.arch }}/minr-desktop.app" || echo "App signing inside DMG failed."
           hdiutil detach /Volumes/minr-desktop
 
       - name: Verify Notarization

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
 
     strategy:
       matrix:
+        os: [macOS-latest, windows-latest]
         node-version: [18.x]
         include:
           - os: macos-latest
@@ -114,6 +115,10 @@ jobs:
       - name: Get version from package.json
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
         shell: bash
+
+      # デバッグ用に追加
+      - name: check files exist
+        run: ls ./dist
 
       - name: Create GitHub Release and Upload Build
         uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ env:
   GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
   GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
   GITHUB_CLIENT_ID: ${{ secrets.APP_GITHUB_CLIENT_ID }}
+  MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+  MAC_CSC_PASSWORD: ${{ secrets.MAC_CSC_PASSWORD }}
+  WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+  WINDOWS_CSC_PASSWORD: ${{ secrets.WINDOWS_CSC_PASSWORD }}
   APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
   APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
   APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
@@ -63,20 +67,20 @@ jobs:
             platform: mac
             architecture: x64
             ext: dmg
-            csc_link: ${{ secrets.MAC_CSC_LINK }}
-            csc_key_password: ${{ secrets.MAC_CSC_PASSWORD }}
+            csc_link: ${{ env.MAC_CSC_LINK }}
+            csc_key_password: ${{ env.MAC_CSC_PASSWORD }}
           - os: macos-14
             platform: mac
             architecture: arm64
             ext: dmg
-            csc_link: ${{ secrets.MAC_CSC_LINK }}
-            csc_key_password: ${{ secrets.MAC_CSC_PASSWORD }}
+            csc_link: ${{ env.MAC_CSC_LINK }}
+            csc_key_password: ${{ env.MAC_CSC_PASSWORD }}
           - os: windows-latest
             platform: win
             architecture: x64
             ext: exe
-            csc_link: ${{ secrets.WINDOWS_CSC_LINK }}
-            csc_key_password: ${{ secrets.WINDOWS_CSC_PASSWORD }}
+            csc_link: ${{ env.WINDOWS_CSC_LINK }}
+            csc_key_password: ${{ env.WINDOWS_CSC_PASSWORD }}
           - os: ubuntu-latest
             platform: linux
             architecture: x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,9 +128,8 @@ jobs:
           DEBUG: electron-osx-sign*
         run: npm run build:${{ matrix.platform }}
 
-      - name: delete Apple API Key File
-        if: startsWith(matrix.os,'macos')
-        run: rm -f ${{ env.APPLE_API_KEY_PATH }}
+      - name: Get version from package.json
+        run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
         shell: bash
 
       - name: Verify DMG Signing
@@ -148,8 +147,9 @@ jobs:
         if: startsWith(matrix.os,'macos')
         run: xcrun stapler validate dist/minr-desktop-*.dmg || echo "Notarization validation failed."
 
-      - name: Get version from package.json
-        run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+      - name: delete Apple API Key File
+        if: startsWith(matrix.os,'macos')
+        run: rm -f ${{ env.APPLE_API_KEY_PATH }}
         shell: bash
 
       - name: Upload Artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macOS-latest, windows-latest]
+        os: [macOS-latest, windows-latest, ubuntu-latest]
         node-version: [18.x]
         include:
           - os: macos-latest
@@ -62,6 +62,9 @@ jobs:
           - os: windows-latest
             platform: win
             ext: exe
+          - os: ubuntu-latest
+            platform: linux
+            ext: AppImage
 
     steps:
       - name: Check out code
@@ -115,6 +118,9 @@ jobs:
       - name: Get version from package.json
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
         shell: bash
+
+      - name: Check file exists
+        run: ls ./dist
 
       - name: Create GitHub Release and Upload Build
         uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-13, macos-14, windows-2022] # ubuntu-24.04
+        os: [windows-2022, macos-13, macos-14, ubuntu-24.04]
         node-version: [18.x]
         include:
+          # Mac版は署名がうまくいっていないため保留
           - os: macos-13
             platform: mac
             ext: dmg
@@ -55,9 +56,9 @@ jobs:
             platform: win
             ext: exe
           # linux版は動作確認できないので見送り
-          # - os: ubuntu-24.04
-          #   platform: linux
-          #   ext: AppImage
+          - os: ubuntu-24.04
+            platform: linux
+            ext: AppImage
 
     steps:
       - name: Check out code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,17 @@ jobs:
             exit 1
           fi
 
+      - name: Check environment exists
+        env:
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_PASSWORD: ${{ secrets.MAC_CSC_PASSWORD }}
+        run: |
+          echo ${#GOOGLE_CLIENT_ID}
+          echo ${#GITHUB_CLIENT_ID}
+          echo ${#MAC_CSC_LINK}
+          echo ${#MAC_CSC_PASSWORD}
+        shell: bash
+
       - name: Create release
         id: create_release
         uses: actions/create-release@v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,8 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  create-release:
+  check-version:
     runs-on: ubuntu-24.04
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
 
     steps:
       - name: Check out code
@@ -36,17 +34,8 @@ jobs:
             exit 1
           fi
 
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1.0.1
-        with:
-          tag_name: ${{ env.PACKAGE_VERSION }}
-          release_name: Release ${{ env.PACKAGE_VERSION }}
-          draft: false
-          prerelease: false
-
-  release:
-    needs: create-release
+  build:
+    needs: check-version
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -137,8 +126,6 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-
-          DEBUG: electron-notarize*
         run: npm run build:${{ matrix.platform }}
 
       - name: delete Apple API Key File
@@ -146,14 +133,24 @@ jobs:
         run: rm -f ${{ env.APPLE_API_KEY_PATH }}
         shell: bash
 
-      - name: Get version from package.json
-        run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
-        shell: bash
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}
+          path: ./dist/minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}.${{ matrix.ext }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /artifacts
 
       - name: Create GitHub Release and Upload Build
-        uses: actions/upload-release-asset@v1.0.1
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./dist/minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}.${{ matrix.ext }}
-          asset_name: minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}-${{ matrix.architecture }}.${{ matrix.ext }}
-          asset_content_type: application/octet-stream
+          files: artifacts/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
         if: startsWith(matrix.os,'macos')
         run: |
           hdiutil attach dist/minr-desktop-*.dmg
-          codesign --verify --deep --strict "/Volumes/minr-desktop ${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}-${{ matrix.arch }}/minr-desktop.app" || echo "App signing inside DMG failed."
+          codesign --verify --deep --strict "/Volumes/minr-desktop ${{ env.PACKAGE_VERSION }}-${{ matrix.arch }}/minr-desktop.app" || echo "App signing inside DMG failed."
           hdiutil detach /Volumes/minr-desktop
 
       - name: Verify Notarization

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-13, macos-14, windows-2022, ubuntu-24.04]
+        os: [macos-13, macos-14, windows-2022] # ubuntu-24.04
         node-version: [18.x]
         include:
           - os: macos-13
@@ -54,9 +54,10 @@ jobs:
           - os: windows-2022
             platform: win
             ext: exe
-          - os: ubuntu-24.04
-            platform: linux
-            ext: AppImage
+          # linux版は動作確認できないので見送り
+          # - os: ubuntu-24.04
+          #   platform: linux
+          #   ext: AppImage
 
     steps:
       - name: Check out code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
 
     strategy:
       matrix:
-        os: [macOS-latest, windows-latest]
         node-version: [18.x]
         include:
           - os: macos-latest
@@ -62,9 +61,6 @@ jobs:
           - os: windows-latest
             platform: win
             ext: exe
-          - os: ubuntu-latest
-            platform: linux
-            ext: AppImage
 
     steps:
       - name: Check out code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,10 +146,7 @@ jobs:
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
           DEBUG: electron-builder
-        run: |
-          echo ${#CSC_LINK}
-          echo ${#CSC_KEY_PASSWORD} 
-          npm run build:${{ matrix.platform }}
+        run: npm run build:${{ matrix.platform }}
 
       - name: Get version from package.json
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,20 +132,20 @@ jobs:
           echo "CSC_KEY_PASSWORD=${MAC_CSC_PASSWORD}" >> $GITHUB_ENV
         shell: bash
 
-      - name: set CSC for Windows
-        if: startsWith(matrix.os,'windows')
-        env:
-          WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
-          WINDOWS_CSC_PASSWORD: ${{ secrets.WINDOWS_CSC_PASSWORD }}
-        run: |
-          echo "CSC_LINK=${WINDOWS_CSC_LINK}" >> $GITHUB_ENV
-          echo "CSC_KEY_PASSWORD=${WINDOWS_CSC_PASSWORD}" >> $GITHUB_ENV
-        shell: bash
+      # windowsのコード署名証明書をsecretsに入れるまでコメントアウト
+      # - name: set CSC for Windows
+      #   if: startsWith(matrix.os,'windows')
+      #   env:
+      #     WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+      #     WINDOWS_CSC_PASSWORD: ${{ secrets.WINDOWS_CSC_PASSWORD }}
+      #   run: |
+      #     echo "CSC_LINK=${WINDOWS_CSC_LINK}" >> $GITHUB_ENV
+      #     echo "CSC_KEY_PASSWORD=${WINDOWS_CSC_PASSWORD}" >> $GITHUB_ENV
+      #   shell: bash
 
       - name: Build Electron App
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
-          DEBUG: electron-builder
         run: npm run build:${{ matrix.platform }}
 
       - name: Get version from package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ env:
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
 
     steps:
       - name: Check out code
@@ -46,6 +44,9 @@ jobs:
           release_name: Release ${{ env.PACKAGE_VERSION }}
           draft: false
           prerelease: false
+
+      - name: Set upload_url output
+        run: echo "upload_url=${{ steps.create_release.outputs.upload_url }}" >> $GITHUB_OUTPUT
 
   release:
     needs: create-release
@@ -88,7 +89,7 @@ jobs:
       - name: Cache dependencies
         # 元々windows版のリリースにのみ書かれていた処理のため
         if: startsWith(matrix.os,'windows')
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules
@@ -119,13 +120,10 @@ jobs:
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
         shell: bash
 
-      - name: Check file exists
-        run: ls ./dist
-
       - name: Create GitHub Release and Upload Build
         uses: actions/upload-release-asset@v1.0.1
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          upload_url: ${{ env.upload_url }}
           asset_path: ./dist/minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}.${{ matrix.ext }}
           asset_name: minr-desktop-${{ env.PACKAGE_VERSION }}-${{ matrix.platform }}.${{ matrix.ext }}
           asset_content_type: application/octet-stream

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -34,8 +34,8 @@ linux:
   icon: build/icon.png
   target:
     - AppImage
-    - snap
-    - deb
+    # - snap
+    # - deb
   maintainer: electronjs.org
   category: Utility
 appImage:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -33,7 +33,7 @@ mac:
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  notarize: true
+  # notarize: true
 dmg:
   artifactName: ${name}-${version}-mac.${ext}
 linux:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -33,6 +33,7 @@ mac:
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
+  forceCodeSigning: true
   notarize: true
 dmg:
   artifactName: ${name}-${version}-mac.${ext}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -28,6 +28,7 @@ mac:
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
+  # notarize: true
 dmg:
   artifactName: ${name}-${version}-mac.${ext}
 linux:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -39,7 +39,7 @@ linux:
   maintainer: electronjs.org
   category: Utility
 appImage:
-  artifactName: ${name}-${version}.${ext}
+  artifactName: ${name}-${version}-linux.${ext}
 npmRebuild: false
 publish:
   null

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,7 +19,7 @@ win:
   publisherName: Altus-Five
   executableName: minr-desktop
 nsis:
-  artifactName: ${name}-${version}-win.${ext}
+  artifactName: ${name}-${version}-win-${arch}.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
@@ -36,7 +36,7 @@ mac:
   forceCodeSigning: true
   notarize: true
 dmg:
-  artifactName: ${name}-${version}-mac.${ext}
+  artifactName: ${name}-${version}-mac-${arch}.${ext}
 linux:
   icon: build/icon.png
   target:
@@ -44,6 +44,6 @@ linux:
   maintainer: electronjs.org
   category: Utility
 appImage:
-  artifactName: ${name}-${version}-linux.${ext}
+  artifactName: ${name}-${version}-linux-${arch}.${ext}
 npmRebuild: false
 publish: null

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -33,7 +33,7 @@ mac:
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  # notarize: true
+  notarize: true
 dmg:
   artifactName: ${name}-${version}-mac.${ext}
 linux:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -14,6 +14,9 @@ asarUnpack:
 afterSign: build/notarize.js
 win:
   icon: build/icon.ico
+  target:
+    - nsis
+  publisherName: Altus-Five
   executableName: minr-desktop
 nsis:
   artifactName: ${name}-${version}-win.${ext}
@@ -22,30 +25,24 @@ nsis:
   createDesktopShortcut: always
 mac:
   icon: build/icon.icns
+  target:
+    - dmg
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  # notarize: true
+  notarize: true
 dmg:
   artifactName: ${name}-${version}-mac.${ext}
 linux:
   icon: build/icon.png
   target:
     - AppImage
-    # - snap
-    # - deb
   maintainer: electronjs.org
   category: Utility
 appImage:
   artifactName: ${name}-${version}-linux.${ext}
 npmRebuild: false
-publish:
-  null
-  # provider: github
-  # owner: minr-dev
-  # repo: desktop
-  # releaseType: release
-  # token: ${env.GITHUB_TOKEN}
+publish: null

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,8 +42,9 @@ appImage:
   artifactName: ${name}-${version}.${ext}
 npmRebuild: false
 publish:
-  provider: github
-  owner: minr-dev
-  repo: desktop
-  releaseType: release
-  token: ${env.GITHUB_TOKEN}
+  never
+  # provider: github
+  # owner: minr-dev
+  # repo: desktop
+  # releaseType: release
+  # token: ${env.GITHUB_TOKEN}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,7 +42,7 @@ appImage:
   artifactName: ${name}-${version}.${ext}
 npmRebuild: false
 publish:
-  never
+  null
   # provider: github
   # owner: minr-dev
   # repo: desktop

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -7,7 +7,7 @@ const envPath = '.env';
 dotenv.config({ path: envPath, debug: true });
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
-const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI || 'https://www.altus5.co.jp/callback';
+const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI || 'http://127.0.0.1/callback';
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
 console.log(`GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}`);
 console.log(`GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI}`);

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -7,7 +7,7 @@ const envPath = '.env';
 dotenv.config({ path: envPath, debug: true });
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
-const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI || 'http://localhost/callback';
+const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI || 'https://www.altus5.co.jp/callback';
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
 console.log(`GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}`);
 console.log(`GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI}`);

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -7,7 +7,7 @@ const envPath = '.env';
 dotenv.config({ path: envPath, debug: true });
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
-const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI || 'https://www.altus5.co.jp/callback';
+const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI || 'http://localhost/callback';
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
 console.log(`GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}`);
 console.log(`GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI}`);

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -7,7 +7,7 @@ const envPath = '.env';
 dotenv.config({ path: envPath, debug: true });
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
-const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI || 'https://localhost/callback';
+const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI || 'https://www.altus5.co.jp/callback';
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
 console.log(`GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}`);
 console.log(`GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.45",
+  "version": "0.1.2-test.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.46",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2",
+  "version": "0.1.2-test.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.18",
+  "version": "0.1.2-test.19",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.36",
+  "version": "0.1.2-test.37",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.17",
+  "version": "0.1.2-test.18",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.39",
+  "version": "0.1.2-test.40",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.41",
+  "version": "0.1.2-test.42",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.15",
+  "version": "0.1.2-test.16",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",
@@ -17,7 +17,7 @@
     "build": "npm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
     "build:win": "npm run build && electron-builder --win --config",
-    "build:mac": "electron-vite build && electron-builder --mac --x64 --arm64 --config",
+    "build:mac": "electron-vite build && electron-builder --mac --x64 --config",
     "build:linux": "electron-vite build && electron-builder --linux --config",
     "test:main": "jest --config jest.config.node.js",
     "test:renderer": "jest --config jest.config.web.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.13",
+  "version": "0.1.2-test.14",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.42",
+  "version": "0.1.2-test.43",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.37",
+  "version": "0.1.2-test.38",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.23",
+  "version": "0.1.2-test.24",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.12",
+  "version": "0.1.2-test.13",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.34",
+  "version": "0.1.2-test.35",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "npm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
     "build:win": "npm run build && electron-builder --win --config",
-    "build:mac": "electron-vite build && electron-builder --mac --config",
+    "build:mac": "electron-vite build && electron-builder --mac --x64 --arm64 --config",
     "build:linux": "electron-vite build && electron-builder --linux --config",
     "test:main": "jest --config jest.config.node.js",
     "test:renderer": "jest --config jest.config.web.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2",
+  "version": "0.1.2-test.47",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.6",
+  "version": "0.1.2-test.7",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.35",
+  "version": "0.1.2-test.36",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.19",
+  "version": "0.1.2-test.20",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.31",
+  "version": "0.1.2-test.32",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.47",
+  "version": "0.1.2",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.28",
+  "version": "0.1.2-test.29",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.43",
+  "version": "0.1.2-test.44",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.33",
+  "version": "0.1.2-test.34",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.4",
+  "version": "0.1.2-test.5",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.22",
+  "version": "0.1.2-test.23",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.5",
+  "version": "0.1.2-test.6",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.9",
+  "version": "0.1.2-test.10",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.10",
+  "version": "0.1.2-test.11",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.14",
+  "version": "0.1.2-test.15",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.46",
+  "version": "0.1.2",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.30",
+  "version": "0.1.2-test.31",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.27",
+  "version": "0.1.2-test.28",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.29",
+  "version": "0.1.2-test.30",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.40",
+  "version": "0.1.2-test.41",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.24",
+  "version": "0.1.2-test.25",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.38",
+  "version": "0.1.2-test.39",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.8",
+  "version": "0.1.2-test.9",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.16",
+  "version": "0.1.2-test.17",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.20",
+  "version": "0.1.2-test.21",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.25",
+  "version": "0.1.2-test.26",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.44",
+  "version": "0.1.2-test.45",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.11",
+  "version": "0.1.2-test.12",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.32",
+  "version": "0.1.2-test.33",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.7",
+  "version": "0.1.2-test.8",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "npm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
     "build:win": "npm run build && electron-builder --win --config",
-    "build:mac": "electron-vite build && electron-builder --mac --x64 --config",
+    "build:mac": "electron-vite build && electron-builder --mac --config",
     "build:linux": "electron-vite build && electron-builder --linux --config",
     "test:main": "jest --config jest.config.node.js",
     "test:renderer": "jest --config jest.config.web.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.21",
+  "version": "0.1.2-test.22",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.26",
+  "version": "0.1.2-test.27",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2-test.45",
+  "version": "0.1.2-test.46",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "msato@altus5.com",

--- a/src/main/services/GoogleAuthServiceImpl.ts
+++ b/src/main/services/GoogleAuthServiceImpl.ts
@@ -192,17 +192,22 @@ export class GoogleAuthServiceImpl implements IAuthService {
         // GoogleからのリダイレクトURLから認証トークンを取り出します
         // 例えば、リダイレクトURLが "http://localhost:5000/callback?code=abcdef" の場合：
         if (url.startsWith(this.redirectUri)) {
-          event.preventDefault();
-          const urlObj = new URL(url);
-          const token = urlObj.searchParams.get('code');
-          if (token) {
-            const credentials = await this.postAuthenticated(url, checks);
-            await this.googleCredentialsService.save(credentials);
-            resolve(token);
-          } else {
-            reject(new Error('No token found'));
+          try {
+            event.preventDefault();
+            const urlObj = new URL(url);
+            const token = urlObj.searchParams.get('code');
+            if (token) {
+              const credentials = await this.postAuthenticated(url, checks);
+              await this.googleCredentialsService.save(credentials);
+              resolve(token);
+            } else {
+              reject(new Error('No token found'));
+            }
+          } catch (e) {
+            reject(e);
+          } finally {
+            this.closeAuthWindow();
           }
-          this.closeAuthWindow();
         }
       });
 


### PR DESCRIPTION
## チケット
#177 

## 実装概要
- ワークフローの修正
  - matrixの利用
  - releaseの作成ライブラリを`softprops/action-gh-release`に変更
- コード署名と公証のプロセスの実装
- Windows以外はコメントアウト
  - 動作しなかったり、動作確認できなかったりするため
- Google認証時のエラーのログ出力
  - 認証中のエラーをrendererに伝える

## 現状の動作状態
- OS毎の起動
  - Mac arm64版はインストールまではいけるが、起動時に署名の問題でエラーがでる
  - Mac x64版も同様
  - Windows版はインストール時に警告はでるが、インストール後は普通に起動できる
    - 証明書を入れれば解消する見込み
  - linux版はリリースまではできているが、動作確認をできていない
- 認証(Windows版で確認)
  - Google認証、GitHub認証ともに動作する
  - ただし、Googleは正規の方法でクライアントIDを発行していない
    - デスクトップアプリなのにユニバーサルWindowsプラットフォーム(UWP)を指定している
    - クライアントシークレットの埋め込みを回避するため
      - https://github.com/minr-dev/desktop/issues/170#issuecomment-2436683623
    - Googleの推奨ではないので、再検討の必要あり
      - https://developers.google.com/identity/protocols/oauth2?hl=ja#installed