### PR TITLE
fix: 機能テストバグ対応 - フォームの保存処理が伝播してしまう不具合の修正

### DIFF
--- a/src/renderer/src/components/crud/CRUDFormDialog.tsx
+++ b/src/renderer/src/components/crud/CRUDFormDialog.tsx
@@ -1,33 +1,42 @@
 import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
 import { ReactNode } from 'react';
+import { FieldValues, FormProvider, UseFormReturn } from 'react-hook-form';
 
-type CRUDFormDialogProps = {
+type CRUDFormDialogProps<TFieldValue extends FieldValues> = {
   isOpen: boolean;
   title: string;
   onClose: () => void;
-  onSubmit: (formData) => void;
+  onSubmit: (formData: TFieldValue) => Promise<void>;
+  methods: UseFormReturn<TFieldValue>;
   children: ReactNode;
 };
 
-export const CRUDFormDialog = ({
+export const CRUDFormDialog = <TFieldValue extends FieldValues>({
   isOpen,
   title,
   onClose,
   onSubmit,
+  methods,
   children,
-}: CRUDFormDialogProps): JSX.Element => {
+}: CRUDFormDialogProps<TFieldValue>): JSX.Element => {
   return (
-    <Dialog open={isOpen} onClose={onClose} PaperProps={{ component: 'form', onSubmit: onSubmit }}>
-      <DialogTitle>{title}</DialogTitle>
-      <DialogContent>{children}</DialogContent>
-      <DialogActions style={{ justifyContent: 'center' }}>
-        <Button type="submit" color="primary" variant="contained">
-          保存
-        </Button>
-        <Button onClick={onClose} color="secondary" variant="contained">
-          キャンセル
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <FormProvider {...methods}>
+      <Dialog
+        open={isOpen}
+        onClose={onClose}
+        PaperProps={{ component: 'form', onSubmit: methods.handleSubmit(onSubmit) }}
+      >
+        <DialogTitle>{title}</DialogTitle>
+        <DialogContent>{children}</DialogContent>
+        <DialogActions style={{ justifyContent: 'center' }}>
+          <Button type="submit" color="primary" variant="contained">
+            保存
+          </Button>
+          <Button onClick={onClose} color="secondary" variant="contained">
+            キャンセル
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </FormProvider>
   );
 };

--- a/src/renderer/src/components/pattern/PatternEdit.tsx
+++ b/src/renderer/src/components/pattern/PatternEdit.tsx
@@ -2,7 +2,7 @@ import rendererContainer from '../../inversify.config';
 import { Alert, Grid, Stack, TextField } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { CRUDFormDialog } from '../crud/CRUDFormDialog';
-import { Controller, useForm, useWatch } from 'react-hook-form';
+import { Controller, useWatch } from 'react-hook-form';
 import { TYPES } from '@renderer/types';
 import { ReadOnlyTextField } from '../common/fields/ReadOnlyTextField';
 import { UniqueConstraintError } from '@shared/errors/UniqueConstraintError';
@@ -15,6 +15,7 @@ import { getLogger } from '@renderer/utils/LoggerUtil';
 import { Pattern } from '@shared/data/Pattern';
 import { IPatternProxy } from '@renderer/services/IPatternProxy';
 import { TaskDropdownComponent } from '../task/TaskDropdownComponent';
+import { useFormManager } from '@renderer/hooks/useFormManager';
 
 interface PatternFormData {
   id: string;
@@ -45,13 +46,16 @@ export const PatternEdit = ({
   logger.info('PatternEdit', isOpen);
   const [isDialogOpen, setDialogOpen] = useState(isOpen);
   const [pattern, setPattern] = useState<Pattern | null>(null);
+  const methods = useFormManager<PatternFormData>({
+    formId: 'pattern-edit-form',
+    isVisible: isOpen,
+  });
   const {
     control,
-    handleSubmit,
     reset,
     formState: { errors: formErrors },
     setError,
-  } = useForm<PatternFormData>();
+  } = methods;
 
   useEffect(() => {
     const fetchData = async (): Promise<void> => {
@@ -114,8 +118,9 @@ export const PatternEdit = ({
     <CRUDFormDialog
       isOpen={isDialogOpen}
       title={`パターン${patternId !== null ? '編集' : '追加'}`}
-      onSubmit={handleSubmit(handleDialogSubmit)}
+      onSubmit={handleDialogSubmit}
       onClose={handleDialogClose}
+      methods={methods}
     >
       <Grid container spacing={2}>
         {patternId !== null && (

--- a/src/renderer/src/components/settings/SettingFormBox.tsx
+++ b/src/renderer/src/components/settings/SettingFormBox.tsx
@@ -1,10 +1,10 @@
 import { Grid, Alert, Button, Box, Stack, Backdrop } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
 import React, { ReactNode } from 'react';
-import { FieldErrors } from 'react-hook-form';
+import { FieldErrors, FormProvider } from 'react-hook-form';
 import { UserPreference } from '@shared/data/UserPreference';
-import { FormContainer } from '../common/form/FormContainer';
 import { getLogger } from '@renderer/utils/LoggerUtil';
+import { useFormManager } from '@renderer/hooks/useFormManager';
 
 /**
  * SettingFormBoxのプロパティインターフェース。
@@ -68,75 +68,80 @@ export const SettingFormBox = ({
     }
   };
 
+  const methods = useFormManager({ formId: 'setting-form' });
+  const { handleSubmit } = methods;
+
   return (
     <>
-      <FormContainer formId="setting-form" onSubmit={handleSettingFormSubmit}>
-        {children}
-        <Box
-          sx={{
-            position: 'sticky',
-            bottom: 0,
-            bgcolor: 'background.default',
-            boxShadow: 1,
-            p: 1,
-            display: 'flex',
-            justifyContent: 'center',
-          }}
-        >
-          <Grid container>
-            <Grid
-              item
-              xs={12}
-              sx={{
-                width: '100%',
-                display: 'flex',
-                justifyContent: 'center',
-              }}
-            >
-              <Stack>
-                {alertMessage && <Alert severity="error">{alertMessage}</Alert>}
-                {Object.entries(errors).length > 0 && (
-                  <Alert severity="error">入力エラーを修正してください</Alert>
-                )}
-                {/** 
+      <FormProvider {...methods}>
+        <form onSubmit={handleSubmit(handleSettingFormSubmit)}>
+          {children}
+          <Box
+            sx={{
+              position: 'sticky',
+              bottom: 0,
+              bgcolor: 'background.default',
+              boxShadow: 1,
+              p: 1,
+              display: 'flex',
+              justifyContent: 'center',
+            }}
+          >
+            <Grid container>
+              <Grid
+                item
+                xs={12}
+                sx={{
+                  width: '100%',
+                  display: 'flex',
+                  justifyContent: 'center',
+                }}
+              >
+                <Stack>
+                  {alertMessage && <Alert severity="error">{alertMessage}</Alert>}
+                  {Object.entries(errors).length > 0 && (
+                    <Alert severity="error">入力エラーを修正してください</Alert>
+                  )}
+                  {/** 
                     デバッグのときにエラーを表示する 
                     ネストされた項目のエラーメッセージは正常に表示されない
                 */}
-                {process.env.NODE_ENV !== 'production' &&
-                  Object.entries(errors).map(([fieldName, error]) => (
-                    <Alert key={fieldName} severity="error">
-                      {fieldName}: {error.message}
-                    </Alert>
-                  ))}
-              </Stack>
-            </Grid>
-            <Grid
-              item
-              xs={12}
-              sx={{
-                width: '100%',
-                display: 'flex',
-                justifyContent: 'center',
-              }}
-            >
-              <Button type="submit" variant="contained" color="primary">
-                保存
-              </Button>
-              <Button
-                variant="contained"
-                color="secondary"
-                style={{
-                  marginLeft: '10px',
-                  marginRight: '30px',
+                  {process.env.NODE_ENV !== 'production' &&
+                    Object.entries(errors).map(([fieldName, error]) => (
+                      <Alert key={fieldName} severity="error">
+                        {fieldName}: {error.message}
+                      </Alert>
+                    ))}
+                </Stack>
+              </Grid>
+              <Grid
+                item
+                xs={12}
+                sx={{
+                  width: '100%',
+                  display: 'flex',
+                  justifyContent: 'center',
                 }}
-                onClick={onCancel}
               >
-                キャンセル
-              </Button>
+                <Button type="submit" variant="contained" color="primary">
+                  保存
+                </Button>
+                <Button
+                  variant="contained"
+                  color="secondary"
+                  style={{
+                    marginLeft: '10px',
+                    marginRight: '30px',
+                  }}
+                  onClick={onCancel}
+                >
+                  キャンセル
+                </Button>
+              </Grid>
             </Grid>
-          </Grid>
-        </Box>
-      </FormContainer>
+          </Box>
+        </form>
+      </FormProvider>
       <Backdrop sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }} open={saving}>
         <CircularProgress color="inherit" />
       </Backdrop>

--- a/src/renderer/src/components/timeTable/EventEntryForm.tsx
+++ b/src/renderer/src/components/timeTable/EventEntryForm.tsx
@@ -1,6 +1,6 @@
 import rendererContainer from '../../inversify.config';
 import React, { useContext, useEffect, useState } from 'react';
-import { Controller, useForm, useWatch } from 'react-hook-form';
+import { Controller, FormProvider, useWatch } from 'react-hook-form';
 import {
   TextField,
   Paper,
@@ -29,6 +29,7 @@ import { ActivityTimeline } from './ActivityTimeline';
 import { TaskDropdownComponent } from '../task/TaskDropdownComponent';
 import { NotificationSettingsFormControl } from '../common/form/NotificationSettingsFormControl';
 import { getLogger } from '@renderer/utils/LoggerUtil';
+import { useFormManager } from '@renderer/hooks/useFormManager';
 
 export const FORM_MODE = {
   NEW: 'NEW',
@@ -100,13 +101,14 @@ const EventEntryForm = ({
   }
   if (logger.isDebugEnabled()) logger.debug('defaultValues', defaultValues);
 
+  const methods = useFormManager<EventEntry>({ formId: 'event-entry-form', isVisible: isOpen });
   const {
     handleSubmit,
     control,
     setValue,
     reset,
     // formState: { errors },
-  } = useForm<EventEntry>();
+  } = methods;
 
   useEffect(() => {
     if (mode === FORM_MODE.EDIT) {
@@ -243,7 +245,7 @@ const EventEntryForm = ({
   };
 
   return (
-    <>
+    <FormProvider {...methods}>
       <CustomDialog
         open={isOpen}
         onClose={handleCloseEventEntryForm}
@@ -491,7 +493,7 @@ const EventEntryForm = ({
           </Button>
         </DialogActions>
       </CustomDialog>
-    </>
+    </FormProvider>
   );
 };
 


### PR DESCRIPTION
## チケット

#207 
テスト課題表 22~24

#169

## 実装概要
- ダイアログが2重に開いているとき、アクティブなダイアログだけ保存処理が行われるように修正