### PR TITLE
fix: 機能テストバグ対応 - 予実追加のvalidateで返される警告が画面に反映されていない

### DIFF
--- a/src/renderer/src/components/timeTable/EventEntryForm.tsx
+++ b/src/renderer/src/components/timeTable/EventEntryForm.tsx
@@ -312,6 +312,12 @@ const EventEntryForm = ({
                       control={control}
                       rules={{
                         required: '入力してください',
+                        validate: (value): string | true => {
+                          if (value && isNaN(value.getDate())) {
+                            return '日付を入力してください';
+                          }
+                          return true;
+                        },
                       }}
                       render={({ field: { onChange, value } }): React.ReactElement => (
                         <DatePicker
@@ -330,8 +336,11 @@ const EventEntryForm = ({
                       rules={{
                         required: '入力してください',
                         validate: (value): string | true => {
+                          if (value && isNaN(value.getDate())) {
+                            return '日付を入力してください';
+                          }
                           if (value && start && value <= start) {
-                            return '終了時間は開始時間よりも後の時間にしてください';
+                            return '終了日は開始日よりも後の日付にしてください';
                           }
                           return true;
                         },
@@ -352,6 +361,12 @@ const EventEntryForm = ({
                       control={control}
                       rules={{
                         required: '入力してください',
+                        validate: (value): string | true => {
+                          if (value && isNaN(value.getDate())) {
+                            return '時間を入力してください';
+                          }
+                          return true;
+                        },
                       }}
                       render={({ field: { onChange, value } }): React.ReactElement => (
                         <TimePicker
@@ -371,6 +386,9 @@ const EventEntryForm = ({
                       rules={{
                         required: '入力してください',
                         validate: (value): string | true => {
+                          if (value && isNaN(value.getDate())) {
+                            return '時間を入力してください';
+                          }
                           if (value && start && value <= start) {
                             return '終了時間は開始時間よりも後の時間にしてください';
                           }

--- a/src/renderer/src/components/timeTable/EventEntryForm.tsx
+++ b/src/renderer/src/components/timeTable/EventEntryForm.tsx
@@ -314,17 +314,26 @@ const EventEntryForm = ({
                         required: '入力してください',
                         validate: (value): string | true => {
                           if (value && isNaN(value.getDate())) {
-                            return '日付を入力してください';
+                            return '日時を入力してください';
                           }
                           return true;
                         },
                       }}
-                      render={({ field: { onChange, value } }): React.ReactElement => (
+                      render={({
+                        field: { onChange, value },
+                        fieldState: { error },
+                      }): React.ReactElement => (
                         <DatePicker
                           label="開始日"
                           value={value}
                           onChange={onChange}
                           format="yyyy/MM/dd"
+                          slotProps={{
+                            textField: {
+                              error: !!error,
+                              helperText: error ? error.message : '',
+                            },
+                          }}
                         />
                       )}
                     />
@@ -337,20 +346,29 @@ const EventEntryForm = ({
                         required: '入力してください',
                         validate: (value): string | true => {
                           if (value && isNaN(value.getDate())) {
-                            return '日付を入力してください';
+                            return '日時を入力してください';
                           }
                           if (value && start && value <= start) {
-                            return '終了日は開始日よりも後の日付にしてください';
+                            return '終了日時は開始日時よりも後の日付にしてください';
                           }
                           return true;
                         },
                       }}
-                      render={({ field: { onChange, value } }): React.ReactElement => (
+                      render={({
+                        field: { onChange, value },
+                        fieldState: { error },
+                      }): React.ReactElement => (
                         <DatePicker
                           label="終了日"
                           value={value}
                           onChange={onChange}
                           format="yyyy/MM/dd"
+                          slotProps={{
+                            textField: {
+                              error: !!error,
+                              helperText: error ? error.message : '',
+                            },
+                          }}
                         />
                       )}
                     />
@@ -363,18 +381,27 @@ const EventEntryForm = ({
                         required: '入力してください',
                         validate: (value): string | true => {
                           if (value && isNaN(value.getDate())) {
-                            return '時間を入力してください';
+                            return '日時を入力してください';
                           }
                           return true;
                         },
                       }}
-                      render={({ field: { onChange, value } }): React.ReactElement => (
+                      render={({
+                        field: { onChange, value },
+                        fieldState: { error },
+                      }): React.ReactElement => (
                         <TimePicker
                           label="開始時間"
                           value={value}
                           onChange={onChange}
                           ampm={false}
                           format="HH:mm"
+                          slotProps={{
+                            textField: {
+                              error: !!error,
+                              helperText: error ? error.message : '',
+                            },
+                          }}
                         />
                       )}
                     />
@@ -387,21 +414,30 @@ const EventEntryForm = ({
                         required: '入力してください',
                         validate: (value): string | true => {
                           if (value && isNaN(value.getDate())) {
-                            return '時間を入力してください';
+                            return '日時を入力してください';
                           }
                           if (value && start && value <= start) {
-                            return '終了時間は開始時間よりも後の時間にしてください';
+                            return '終了日時は開始日時よりも後の時間にしてください';
                           }
                           return true;
                         },
                       }}
-                      render={({ field: { onChange, value } }): React.ReactElement => (
+                      render={({
+                        field: { onChange, value },
+                        fieldState: { error },
+                      }): React.ReactElement => (
                         <TimePicker
                           label="終了時間"
                           value={value}
                           onChange={onChange}
                           ampm={false}
                           format="HH:mm"
+                          slotProps={{
+                            textField: {
+                              error: !!error,
+                              helperText: error ? error.message : '',
+                            },
+                          }}
                         />
                       )}
                     />

--- a/src/renderer/src/components/timeTable/EventEntryForm.tsx
+++ b/src/renderer/src/components/timeTable/EventEntryForm.tsx
@@ -312,10 +312,8 @@ const EventEntryForm = ({
                       control={control}
                       rules={{
                         required: '入力してください',
-                        validate: (value): string | true => {
-                          if (value && isNaN(value.getDate())) {
-                            return '日時を入力してください';
-                          }
+                        validate: (value): boolean => {
+                          if (value && isNaN(value.getDate())) return false;
                           return true;
                         },
                       }}
@@ -331,7 +329,6 @@ const EventEntryForm = ({
                           slotProps={{
                             textField: {
                               error: !!error,
-                              helperText: error ? error.message : '',
                             },
                           }}
                         />
@@ -344,13 +341,9 @@ const EventEntryForm = ({
                       control={control}
                       rules={{
                         required: '入力してください',
-                        validate: (value): string | true => {
-                          if (value && isNaN(value.getDate())) {
-                            return '日時を入力してください';
-                          }
-                          if (value && start && value <= start) {
-                            return '終了日時は開始日時よりも後の日付にしてください';
-                          }
+                        validate: (value): boolean => {
+                          if (value && isNaN(value.getDate())) return false;
+                          if (value && start && value <= start) return false;
                           return true;
                         },
                       }}
@@ -366,7 +359,6 @@ const EventEntryForm = ({
                           slotProps={{
                             textField: {
                               error: !!error,
-                              helperText: error ? error.message : '',
                             },
                           }}
                         />
@@ -417,7 +409,7 @@ const EventEntryForm = ({
                             return '日時を入力してください';
                           }
                           if (value && start && value <= start) {
-                            return '終了日時は開始日時よりも後の時間にしてください';
+                            return '終了日時は開始日時よりも後の日時にしてください';
                           }
                           return true;
                         },


### PR DESCRIPTION
## チケット

#214 

## 対応内容

* Context
    * 入力エラーが発生した場合は対象のフォームが強調表示され、ヘルパーテキストが表示される仕様となっている。
    * 日時の入力エラー時に強調表示がされていないため修正する必要がある。
* Decision
    * `Picker`に`slotProps`の`textField`を追加し、入力エラーの強調表示を実装する。
* Consequences
    * `DatePicker`、`TimePicker`では`slotProps`の`textField`にてテキストフォームと同様のエラー表示ができる。

## 補足

* 修正箇所が重複するため、マージ先は修正関連するブランチとする。