### PR TITLE
fix: 機能テストバグ対応 - 工数の再設定フォームの修正

### DIFF
--- a/src/renderer/src/components/timeTable/ExtraAllocationForm.tsx
+++ b/src/renderer/src/components/timeTable/ExtraAllocationForm.tsx
@@ -70,21 +70,26 @@ const ExtraAllocationForm = (
 
   useEffect(() => {
     reset({
-      allocations: overrunTasks.map(({ taskId, schduledTime: actualTimeMs }) => {
-        const task = taskMap.get(taskId);
-        if (task == null) {
-          throw new Error();
-        }
-        const project = projectMap.get(task.projectId);
-        return {
+      allocations: overrunTasks.map(
+        ({
           taskId,
-          taskName: task.name,
-          projectName: project?.name,
-          plannedHours: task.plannedHours,
-          actualMinutes: Math.floor(actualTimeMs / (60 * 1000)),
-          allocateHours: undefined,
-        };
-      }),
+          schduledTime: actualTimeMs,
+        }): Partial<ExtraAllocationFormData['allocations'][number]> => {
+          const task = taskMap.get(taskId);
+          if (task == null) {
+            throw new Error('Task was not found.');
+          }
+          const project = projectMap.get(task.projectId);
+          return {
+            taskId,
+            taskName: task.name,
+            projectName: project?.name,
+            estimatedHours: task.plannedHours,
+            scheduledMinutes: Math.floor(actualTimeMs / (60 * 1000)),
+            extraAllocateHours: undefined,
+          };
+        }
+      ),
     });
   }, [overrunTasks, projectMap, reset, taskMap]);
 

--- a/src/renderer/src/components/timeTable/ExtraAllocationItem.tsx
+++ b/src/renderer/src/components/timeTable/ExtraAllocationItem.tsx
@@ -10,9 +10,16 @@ interface ExtraAllocationItemProps {
 
 export const ExtraAllocationItem = ({ index, control }: ExtraAllocationItemProps): JSX.Element => {
   const taskData = useWatch({ control, name: `allocations.${index}` });
-  const scheduledTime = {
-    hours: Math.floor(taskData.scheduledMinutes / 60),
-    minutes: taskData.scheduledMinutes % 60,
+  const formatTime = (minutes: number): string => {
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    if (!hours) {
+      return `${remainingMinutes}分`;
+    }
+    if (!remainingMinutes) {
+      return `${hours}時間`;
+    }
+    return `${hours}時間${remainingMinutes}分`;
   };
   return (
     <Paper variant="outlined" style={{ marginTop: '1ch' }}>
@@ -23,13 +30,12 @@ export const ExtraAllocationItem = ({ index, control }: ExtraAllocationItemProps
         <Grid item xs={3}>
           {taskData.projectName && <Chip label={taskData.projectName} />}
         </Grid>
-        <Grid item xs={6}>
+        <Grid item xs={4}>
           <Typography variant="body1">見積工数: {taskData.estimatedHours}時間</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid item xs={8}>
           <Typography variant="body1">
-            予定登録された合計時間: {scheduledTime.hours ? `${scheduledTime.hours}時間` : ''}
-            {scheduledTime.minutes}分
+            予定登録された合計時間: {formatTime(taskData.scheduledMinutes)}
           </Typography>
         </Grid>
         <Grid item xs={0}>

--- a/src/renderer/src/hooks/useAutoRegistrationPlan.ts
+++ b/src/renderer/src/hooks/useAutoRegistrationPlan.ts
@@ -82,16 +82,19 @@ export const useAutoRegistrationPlan = ({
     selectedDate: Date,
     extraAllocation: Map<string, number>
   ): Promise<void> => {
-    if (logger.isDebugEnabled()) logger.debug('handleConfirmExtraAllocation');
+    if (logger.isDebugEnabled()) logger.debug('handleConfirmExtraAllocationForm');
     handleAutoRegisterProvisional(selectedDate, extraAllocation);
     setFormOpen(false);
-    setOverrunTasks([]);
+    // 確定時、追加工数フォームが閉じる前に overrunTask が空になって、一瞬中身のないフォームが映ってしまう。
+    // 空にしなくとも動作はするので、ひとまずコメントアウトで対応する。
+    // setOverrunTasks([]);
   };
 
   const handleCloseForm = async (): Promise<void> => {
-    if (logger.isDebugEnabled()) logger.debug('handleCloseEventEntryForm');
+    if (logger.isDebugEnabled()) logger.debug('handleCloseExtraAllocationForm');
     setFormOpen(false);
-    setOverrunTasks([]);
+    // handleCondirmExtraAllocation と同じ理由でコメントアウト
+    // setOverrunTasks([]);
   };
 
   return {


### PR DESCRIPTION
## チケット
#219 

## 実装内容
- 見積もり工数と予定登録された合計時間が正常に表示されない不具合を修正
- 閉じる際に、一瞬中身が空の工数の再設定フォームが映ってしまうのを修正
- ログ出力の修正