### PR TITLE
fix: 機能テストバグ対応 - タスク追加・編集でプロジェクトが未選択のまま保存できてしまう

### DIFF
--- a/src/renderer/src/components/task/TaskEdit.tsx
+++ b/src/renderer/src/components/task/TaskEdit.tsx
@@ -169,7 +169,15 @@ export const TaskEdit = ({ isOpen, taskId, onClose, onSubmit }: TaskEditProps): 
           <Controller
             name="projectId"
             control={control}
-            rules={{ required: '入力してください。' }}
+            rules={{
+              required: '入力してください。',
+              validate: (value): string | true => {
+                if (value === 'NULL') {
+                  return '入力してください。';
+                }
+                return true;
+              },
+            }}
             render={({ field: { onChange, value }, fieldState: { error } }): JSX.Element => (
               <FormControl fullWidth>
                 <ProjectDropdownComponent value={value} onChange={onChange} />
@@ -294,11 +302,21 @@ export const TaskEdit = ({ isOpen, taskId, onClose, onSubmit }: TaskEditProps): 
             )}
           />
         </Grid>
-        <Stack>
-          {Object.entries(formErrors).length > 0 && (
-            <Alert severity="error">入力エラーを修正してください</Alert>
-          )}
-        </Stack>
+        <Grid
+          item
+          xs={12}
+          sx={{
+            width: '100%',
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+        >
+          <Stack>
+            {Object.entries(formErrors).length > 0 && (
+              <Alert severity="error">入力エラーを修正してください</Alert>
+            )}
+          </Stack>
+        </Grid>
       </Grid>
     </CRUDFormDialog>
   );


### PR DESCRIPTION
## チケット

#225 

## 対応内容

* Context
    * タスクの追加ではタスクがプロジェクトと必ず紐づいているため、プロジェクトの選択は必須となっている。
    * タスク追加・編集ではプロジェクトが選択されているときに保存を実行する。
* Decision
    * `プロジェクトなし(NULL)`に対して`validate`を追加し入力エラーを表示されるようにする。
* Consequences
    * タスク追加・編集のプロジェクトにて`プロジェクトなし`が選択されているときにNULLの文字が入っているため、`required`が機能していなかった。
    * `プロジェクトなし`が選択されているときの文字列を判定し`validate`を設定する必要がある。

## 補足

* テスト課題表2の修正も併せて実施
