### PR TITLE
fix: 機能テストバグ対応 - ポモドーロタイマー設定の入力エラー表示が機能していない

### DIFF
--- a/src/renderer/src/components/common/form/NotificationSettingsFormControl.tsx
+++ b/src/renderer/src/components/common/form/NotificationSettingsFormControl.tsx
@@ -118,7 +118,7 @@ export const NotificationSettingsFormControl = <
                 required: '入力してください。',
                 min: { value: 0, message: '0以上の値を入力してください。' },
               }}
-              render={({ field }): JSX.Element => (
+              render={({ field, fieldState: { error } }): JSX.Element => (
                 <>
                   <TextField
                     {...field}
@@ -131,6 +131,7 @@ export const NotificationSettingsFormControl = <
                         min: 0,
                       },
                     }}
+                    error={!!error}
                     {...notificationTimeOffsetProps}
                   />
                   <FormHelperText>0以上の値を入力してください。</FormHelperText>


### PR DESCRIPTION
## チケット

#224 

## 対応内容

* Context
    * フォーム入力にエラーがある場合は、入力エラーの表示をする必要がある。
* Decision
    * 通知タイミングの`Textfield`に`error`の項目を追加する。
* Consequences
    * ポモドーロタイマー設定の`Textfield`を確認したところ、入力エラーの表示に必要な`error`が抜けていた。
