### PR TITLE
fix: 機能テストバグ対応 - 予定の自動登録の不具合の修正

### DIFF
--- a/src/main/services/EventAggregationServiceImpl.ts
+++ b/src/main/services/EventAggregationServiceImpl.ts
@@ -15,9 +15,9 @@ export class EventAggregationServiceImpl implements IEventAggregationService {
   ) {}
 
   async getPlannedTimeByTasks(userId: string, taskIds: string[]): Promise<Map<string, number>> {
-    const plans = (await this.eventEntryService.getAllByTasks(userId, taskIds)).filter(
-      (event) => event.eventType == EVENT_TYPE.PLAN || event.eventType == EVENT_TYPE.SHARED
-    );
+    const plans = (await this.eventEntryService.getAllByTasks(userId, taskIds))
+      .filter((event) => event.eventType == EVENT_TYPE.PLAN || event.eventType == EVENT_TYPE.SHARED)
+      .filter((event) => !event.deleted);
     const planningTimeData = taskIds.map((taskId): [string, number] => [
       taskId,
       this.aggregateEventTime(plans.filter((plan) => plan.taskId === taskId)),

--- a/src/main/services/TaskAllocationServiceImpl.ts
+++ b/src/main/services/TaskAllocationServiceImpl.ts
@@ -141,7 +141,7 @@ export class TaskAllocationServiceImpl implements ITaskAllocationService {
 
     const extractedSlots: TimeSlot<Date>[] = [];
     while (remainingTime > 0 && remainingSlots.length > 0) {
-      const timeSlot = remainingSlots.pop();
+      const timeSlot = remainingSlots.shift();
       if (!timeSlot) {
         break;
       }

--- a/src/main/services/TaskServiceImpl.ts
+++ b/src/main/services/TaskServiceImpl.ts
@@ -80,8 +80,23 @@ export class TaskServiceImpl implements ITaskService {
       status: TASK_STATUS.UNCOMPLETED,
       plannedHours: { $ne: null, $exists: true },
     };
-    const sort = { priority: -1, dueDate: 1 };
-    return await this.dataSource.find(this.tableName, query, sort);
+    // 本来であればDB側のソート機能を使いたい
+    // しかし、NeDBに null 値の順番を調整する機能がないため、javaScriptでソートを行う
+    return (await this.dataSource.find(this.tableName, query)).sort((t1, t2) => {
+      if (t1.priority !== t2.priority) {
+        return t2.priority - t1.priority;
+      }
+      if (!t1.dueDate && !t2.dueDate) {
+        return 0;
+      }
+      if (!t1.dueDate) {
+        return 1;
+      }
+      if (!t2.dueDate) {
+        return -1;
+      }
+      return t1.dueDate.getTime() - t2.dueDate.getTime();
+    });
   }
 
   /**

--- a/src/main/services/UserPreferenceStoreServiceImpl.ts
+++ b/src/main/services/UserPreferenceStoreServiceImpl.ts
@@ -31,7 +31,7 @@ export class UserPreferenceStoreServiceImpl implements IUserPreferenceStoreServi
     startHourLocal: 9,
     dailyWorkStartTime: { hours: 10, minutes: 0 },
     dailyWorkHours: 8,
-    dailyBreakTimeSlots: [{ start: { hours: 10, minutes: 0 }, end: { hours: 13, minutes: 0 } }],
+    dailyBreakTimeSlots: [{ start: { hours: 12, minutes: 0 }, end: { hours: 13, minutes: 0 } }],
 
     speakEvent: false,
     speakEventTimeOffset: 10,


### PR DESCRIPTION
## チケット
#220 #221

## 実装内容
- 予定の自動登録の際、期限日のあるタスクがないタスクより優先させるよう修正
- 予定の自動登録の際、予定登録済みなどで時間帯が2つにわかれた場合、早い方の時間帯から予定を登録するよう修正
- 登録済みの予定工数の計算で、論理削除された予定が計算対象に含まれてしまう不具合を修正
- 休憩時間のデフォルト値を修正