### PR TITLE
fix: 機能テストバグ対応 - 工数の再設定フォームの表示条件の調整

### DIFF
--- a/src/main/inversify.main.config.ts
+++ b/src/main/inversify.main.config.ts
@@ -90,6 +90,8 @@ import { TaskAllocationServiceImpl } from './services/TaskAllocationServiceImpl'
 import { IEventAggregationService } from './services/IEventAggregationService';
 import { EventAggregationServiceImpl } from './services/EventAggregationServiceImpl';
 import { PlanAutoRegistrationServiceHandlerImpl } from './ipc/PlanAutoRegistrationServiceHandlerImpl';
+import { ITaskProviderService } from './services/ITaskProviderService';
+import { TaskProviderServiceImpl } from './services/TaskProviderServiceImpl';
 
 // コンテナの作成
 const container = new Container();
@@ -252,6 +254,10 @@ container
 container
   .bind<IPlanAvailableTimeSlotService>(TYPES.PlanAvailableTimeSlotService)
   .to(PlanAvailableTimeSlotServiceImpl)
+  .inSingletonScope();
+container
+  .bind<ITaskProviderService>(TYPES.TaskProviderService)
+  .to(TaskProviderServiceImpl)
   .inSingletonScope();
 container
   .bind<ITaskAllocationService>(TYPES.TaskAllocationService)

--- a/src/main/services/EventAggregationServiceImpl.ts
+++ b/src/main/services/EventAggregationServiceImpl.ts
@@ -15,9 +15,9 @@ export class EventAggregationServiceImpl implements IEventAggregationService {
   ) {}
 
   async getPlannedTimeByTasks(userId: string, taskIds: string[]): Promise<Map<string, number>> {
-    const plans = (await this.eventEntryService.getAllByTasks(userId, taskIds)).filter(
-      (event) => event.eventType == EVENT_TYPE.PLAN || event.eventType == EVENT_TYPE.SHARED
-    );
+    const plans = (await this.eventEntryService.getAllByTasks(userId, taskIds))
+      .filter((event) => event.eventType == EVENT_TYPE.PLAN || event.eventType == EVENT_TYPE.SHARED)
+      .filter((event) => !event.deleted);
     const planningTimeData = taskIds.map((taskId): [string, number] => [
       taskId,
       this.aggregateEventTime(plans.filter((plan) => plan.taskId === taskId)),

--- a/src/main/services/ITaskAllocationService.ts
+++ b/src/main/services/ITaskAllocationService.ts
@@ -1,9 +1,11 @@
 import { TimeSlot } from '@shared/data/TimeSlot';
 import { TaskAllocationResult } from '@shared/data/TaskAllocationResult';
+import { Task } from '@shared/data/Task';
 
 export interface ITaskAllocationService {
   allocate(
     timeSlot: TimeSlot<Date>[],
+    tasks: Task[],
     taskExtraHours?: Map<string, number>
   ): Promise<TaskAllocationResult>;
 }

--- a/src/main/services/ITaskProviderService.ts
+++ b/src/main/services/ITaskProviderService.ts
@@ -1,0 +1,5 @@
+import { Task } from '@shared/data/Task';
+
+export interface ITaskProviderService {
+  getTasksForAllocation(targetDate: Date): Promise<Task[]>;
+}

--- a/src/main/services/PlanAutoRegistrationServiceImpl.ts
+++ b/src/main/services/PlanAutoRegistrationServiceImpl.ts
@@ -8,21 +8,25 @@ import { EventEntry, EVENT_TYPE } from '@shared/data/EventEntry';
 import { addDays } from 'date-fns';
 import type { ITaskAllocationService } from './ITaskAllocationService';
 import type { IPlanAvailableTimeSlotService } from './IPlanAvailableTimeSlotService';
+import type { ITaskProviderService } from './ITaskProviderService';
 
 /**
  * 予定の自動登録を行うサービスクラス
  *
  * - PlanAvailableTimeSlotService
  *   - 予定の空き時間を計算するサービスクラス。これで取得した空き時間に仮の予定を作成する。
+ * - TaskProviderService
+ *   - 割り当てるタスクを優先度順に取得するサービスクラス。
  * - TaskAllocationService
- *   - 空き時間に、タスクの優先度順にタスクの予定を作成する。
+ *   - TaskProviderServiceから受け取ったタスクをもとに、予定を作成する。
  *   - タスクの実績工数が予定工数を上回っている場合は、その情報を返却し、予定の作成は取りやめる。
  *
  * 実際の流れ
  * 1. PlanAvailableTimeSlotService から空き時間を取得
- * 2. TaskAllocationService で予定を作成または超過情報を返却
- * 3-a. 予定が作成された場合はそれを仮登録状態で保存し、success: true で終了
- * 3-b. 超過情報が返却された場合は予定の登録は行わず、success: false とともに超過情報を返して終了
+ * 2. TaskProviderService で割り当てるタスクを取得
+ * 3. TaskAllocationService で予定を作成または超過情報を返却
+ * 4-a. 予定が作成された場合はそれを仮登録状態で保存し、success: true で終了
+ * 4-b. 超過情報が返却された場合は予定の登録は行わず、success: false とともに超過情報を返して終了
  *
  * 超過情報が返った後はrenderer側で超過しているタスクに追加で割り当てる工数を入力し、taskExtraHours にいれて再び呼び出す。
  * taskExtraHours に工数が入っているタスクはそこから優先的に割り当て工数が決められ、超過情報のチェックは行われない。
@@ -39,6 +43,8 @@ export class PlanAutoRegistrationServiceImpl implements IPlanAutoRegistrationSer
     private readonly eventEntryService: IEventEntryService,
     @inject(TYPES.PlanAvailableTimeSlotService)
     private readonly planAvailableTimeSlotService: IPlanAvailableTimeSlotService,
+    @inject(TYPES.TaskProviderService)
+    private readonly taskProviderService: ITaskProviderService,
     @inject(TYPES.TaskAllocationService)
     private readonly taskAllocationService: ITaskAllocationService
   ) {}
@@ -50,8 +56,10 @@ export class PlanAutoRegistrationServiceImpl implements IPlanAutoRegistrationSer
     const freeSlots = await this.planAvailableTimeSlotService.calculateAvailableTimeSlot(
       targetDate
     );
+    const tasks = await this.taskProviderService.getTasksForAllocation(targetDate);
     const taskAllocationResult = await this.taskAllocationService.allocate(
       freeSlots,
+      tasks,
       taskExtraHours
     );
     if (taskAllocationResult.overrunTasks.length > 0) {

--- a/src/main/services/TaskAllocationServiceImpl.ts
+++ b/src/main/services/TaskAllocationServiceImpl.ts
@@ -141,7 +141,7 @@ export class TaskAllocationServiceImpl implements ITaskAllocationService {
 
     const extractedSlots: TimeSlot<Date>[] = [];
     while (remainingTime > 0 && remainingSlots.length > 0) {
-      const timeSlot = remainingSlots.pop();
+      const timeSlot = remainingSlots.shift();
       if (!timeSlot) {
         break;
       }

--- a/src/main/services/TaskProviderServiceImpl.ts
+++ b/src/main/services/TaskProviderServiceImpl.ts
@@ -1,0 +1,47 @@
+import { Task } from '@shared/data/Task';
+import { inject, injectable } from 'inversify';
+import { ITaskProviderService } from './ITaskProviderService';
+import { TYPES } from '@main/types';
+import type { IEventEntryService } from './IEventEntryService';
+import type { ITaskService } from './ITaskService';
+import type { IUserDetailsService } from './IUserDetailsService';
+import { addDays } from 'date-fns';
+import { EVENT_TYPE } from '@shared/data/EventEntry';
+import { getLogger } from '@main/utils/LoggerUtil';
+
+const logger = getLogger('TaskProviderService');
+
+/**
+ * 予定の自動登録で使うクラス。
+ * 自動登録で割り当てるタスクを優先順位をつけて返す。
+ * タスクは未完了のものの中から、優先度の高い順に返される。
+ * 優先度が同じタスクに関しては、期限日の早い順に並べられ、
+ * 期限日のないタスクは同じ優先度内で最後に並べられる。
+ * @see PlanAutoRegistrationServiceImpl
+ */
+@injectable()
+export class TaskProviderServiceImpl implements ITaskProviderService {
+  constructor(
+    @inject(TYPES.UserDetailsService)
+    private readonly userDetailsService: IUserDetailsService,
+    @inject(TYPES.EventEntryService)
+    private readonly eventEntryService: IEventEntryService,
+    @inject(TYPES.TaskService)
+    private readonly taskService: ITaskService
+  ) {}
+  // TODO: 単体テストの実装
+  async getTasksForAllocation(targetDate: Date): Promise<Task[]> {
+    const userId = await this.userDetailsService.getUserId();
+    const start = targetDate;
+    const end = addDays(targetDate, 1);
+    const plans = (await this.eventEntryService.list(userId, start, end))
+      .filter((event) => event.eventType == EVENT_TYPE.PLAN || event.eventType == EVENT_TYPE.SHARED)
+      .filter((event) => !event.deleted);
+    const schduledTaskIds = plans
+      .map((plan) => plan.taskId)
+      .filter((taskId): taskId is string => taskId != null);
+    logger.debug(schduledTaskIds);
+    const tasks = await this.taskService.getUncompletedByPriority();
+    return tasks.filter((task) => !schduledTaskIds.includes(task.id));
+  }
+}

--- a/src/main/services/TaskProviderServiceImpl.ts
+++ b/src/main/services/TaskProviderServiceImpl.ts
@@ -7,9 +7,6 @@ import type { ITaskService } from './ITaskService';
 import type { IUserDetailsService } from './IUserDetailsService';
 import { addDays } from 'date-fns';
 import { EVENT_TYPE } from '@shared/data/EventEntry';
-import { getLogger } from '@main/utils/LoggerUtil';
-
-const logger = getLogger('TaskProviderService');
 
 /**
  * 予定の自動登録で使うクラス。
@@ -40,7 +37,6 @@ export class TaskProviderServiceImpl implements ITaskProviderService {
     const schduledTaskIds = plans
       .map((plan) => plan.taskId)
       .filter((taskId): taskId is string => taskId != null);
-    logger.debug(schduledTaskIds);
     const tasks = await this.taskService.getUncompletedByPriority();
     return tasks.filter((task) => !schduledTaskIds.includes(task.id));
   }

--- a/src/main/services/TaskServiceImpl.ts
+++ b/src/main/services/TaskServiceImpl.ts
@@ -80,8 +80,23 @@ export class TaskServiceImpl implements ITaskService {
       status: TASK_STATUS.UNCOMPLETED,
       plannedHours: { $ne: null, $exists: true },
     };
-    const sort = { priority: -1, dueDate: 1 };
-    return await this.dataSource.find(this.tableName, query, sort);
+    // 本来であればDB側のソート機能を使いたい
+    // しかし、NeDBに null 値の順番を調整する機能がないため、javaScriptでソートを行う
+    return (await this.dataSource.find(this.tableName, query)).sort((t1, t2) => {
+      if (t1.priority !== t2.priority) {
+        return t2.priority - t1.priority;
+      }
+      if (!t1.dueDate && !t2.dueDate) {
+        return 0;
+      }
+      if (!t1.dueDate) {
+        return 1;
+      }
+      if (!t2.dueDate) {
+        return -1;
+      }
+      return t1.dueDate.getTime() - t2.dueDate.getTime();
+    });
   }
 
   /**

--- a/src/main/services/UserPreferenceStoreServiceImpl.ts
+++ b/src/main/services/UserPreferenceStoreServiceImpl.ts
@@ -31,7 +31,7 @@ export class UserPreferenceStoreServiceImpl implements IUserPreferenceStoreServi
     startHourLocal: 9,
     dailyWorkStartTime: { hours: 10, minutes: 0 },
     dailyWorkHours: 8,
-    dailyBreakTimeSlots: [{ start: { hours: 10, minutes: 0 }, end: { hours: 13, minutes: 0 } }],
+    dailyBreakTimeSlots: [{ start: { hours: 12, minutes: 0 }, end: { hours: 13, minutes: 0 } }],
 
     speakEvent: false,
     speakEventTimeOffset: 10,

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -32,6 +32,7 @@ export const TYPES = {
   ActualAutoRegistrationFinalizer: Symbol.for('ActualAutoRegistrationFinalizer'),
   PlanAutoRegistrationService: Symbol.for('PlanAutoRegistrationService'),
   PlanAvailableTimeSlotService: Symbol.for('PlanAvailableTimeSlotService'),
+  TaskProviderService: Symbol.for('TaskProviderService'),
   TaskAllocationService: Symbol.for('TaskAllocationService'),
   EventAggregationService: Symbol.for('EventAggrgationService'),
 


### PR DESCRIPTION
## チケット
#223 

## 実装内容
- 予定自動登録を行う際、その日の予定に登録済みのタスクは、自動登録対象から外すようにする
- 自動登録対象のタスクを抽出する処理を別クラスに分離