### PR TITLE
fix: 仮登録状態のイベントの保存・削除処理を修正

### DIFF
--- a/src/renderer/src/components/timeTable/EventEntryForm.tsx
+++ b/src/renderer/src/components/timeTable/EventEntryForm.tsx
@@ -89,7 +89,6 @@ const EventEntryForm = ({
   logger.info('EventEntryForm', isOpen, eventEntry);
   const defaultValues = { ...eventEntry };
   const targetDateTime = targetDate?.getTime();
-  const isProvisional = eventEntry?.isProvisional;
   if (targetDate && mode === FORM_MODE.NEW) {
     defaultValues.start = {
       dateTime: addHours(startOfDay(targetDate), startHour),
@@ -188,9 +187,7 @@ const EventEntryForm = ({
     try {
       const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);
       let ee: EventEntry | undefined;
-      if (isProvisional) {
-        ee = eventEntry;
-      } else if (data.id && String(data.id).length > 0) {
+      if (data.id && String(data.id).length > 0) {
         const id = `${data.id}`;
         ee = await eventEntryProxy.get(id);
         if (!ee) {
@@ -207,12 +204,8 @@ const EventEntryForm = ({
         );
       }
       const merged = { ...ee, ...inputData };
-      if (!isProvisional) {
-        const saved = await eventEntryProxy.save(merged);
-        await onSubmit(saved);
-      } else {
-        await onSubmit(merged);
-      }
+      const saved = await eventEntryProxy.save(merged);
+      await onSubmit(saved);
     } catch (err) {
       logger.error(err);
       throw err;
@@ -231,10 +224,8 @@ const EventEntryForm = ({
     const deletedId = eventEntry.id;
     if (logger.isDebugEnabled()) logger.debug('deletedId', deletedId);
     try {
-      if (!eventEntry.isProvisional) {
-        const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);
-        await eventEntryProxy.delete(deletedId);
-      }
+      const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);
+      await eventEntryProxy.delete(deletedId);
       await onDelete();
     } catch (err) {
       logger.error(err);

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -271,20 +271,16 @@ const TimeTable = (): JSX.Element => {
 
   const handleResizeStop = (state: DragDropResizeState): void => {
     if (logger.isDebugEnabled()) logger.debug('start handleResizeStop', state.eventTimeCell);
-    if (!state.eventTimeCell.event.isProvisional) {
-      const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);
-      eventEntryProxy.save(state.eventTimeCell.event);
-    }
+    const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);
+    eventEntryProxy.save(state.eventTimeCell.event);
     updateEventEntry([state.eventTimeCell.event]);
     if (logger.isDebugEnabled()) logger.debug('end handleResizeStop', state.eventTimeCell);
   };
 
   const handleDragStop = (state: DragDropResizeState): void => {
     if (logger.isDebugEnabled()) logger.debug('start handleDragStop', state.eventTimeCell);
-    if (!state.eventTimeCell.event.isProvisional) {
-      const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);
-      eventEntryProxy.save(state.eventTimeCell.event);
-    }
+    const eventEntryProxy = rendererContainer.get<IEventEntryProxy>(TYPES.EventEntryProxy);
+    eventEntryProxy.save(state.eventTimeCell.event);
     updateEventEntry([state.eventTimeCell.event]);
     if (logger.isDebugEnabled()) logger.debug('end handleDragStop', state.eventTimeCell);
   };


### PR DESCRIPTION
## チケット
#204 

## 実装内容
- 仮登録状態のイベントの保存時に、DBにも保存するよう修正
- 仮登録状態のイベントの削除時に、DBからも削除するよう修正
- 仮登録状態のイベントをリサイズした時に、DBの時間も更新するよう修正
- 仮登録状態のイベントのドラッグ&ドロップした時に、DBの時間も更新するよう修正