### PR TITLE
fix: 機能テストバグ対応 - カラーの選択時にタイトルと入力した値が重なってしまう

### DIFF
--- a/src/renderer/src/components/common/fields/TextColorPickerField.tsx
+++ b/src/renderer/src/components/common/fields/TextColorPickerField.tsx
@@ -53,6 +53,9 @@ export const TextColorPickerField = ({
         helperText={helperText}
         fullWidth={fullWidth !== undefined ? fullWidth : true}
         margin={margin !== undefined ? margin : 'normal'}
+        InputLabelProps={{
+          shrink: field.value !== undefined && field.value !== '',
+        }}
       />
       <Menu
         id={`color-picker-menu-${field.id}`}


### PR DESCRIPTION
## チケット

#232 

## 対応内容

* Context
    * 入力フォームはデザインを`outlined`で統一している。
    * フォームに入力した際は、そのフォームが何なのかわかるようにタイトルが常に見えている状態にする。
* Decision
    * `shrink`を追加し、`value`が入っている場合は常に縮小するように修正する。
* Consequences
    * `InputLabelProps`の`shrink`では`label`を常に縮小する設定を行うことができる。
    * `shrink`に`value`の入力判定を記載することで、外部からの入力でもタイトルを縮小することができる。
