### PR TITLE
fix: ユーザーコード入力画面を二重に開けないようにする

### DIFF
--- a/src/main/ipc/GitHubAuthServiceHandlerImpl.ts
+++ b/src/main/ipc/GitHubAuthServiceHandlerImpl.ts
@@ -28,7 +28,7 @@ export class GitHubAuthServiceHandlerImpl implements IIpcHandlerInitializer {
       IpcChannel.GITHUB_SHOW_USER_CODE_INPUT_WINDOW,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       async (_event: IpcMainInvokeEvent) => {
-        console.log(`ipcMain handle ${IpcChannel.GITHUB_SHOW_USER_CODE_INPUT_WINDOW}`);
+        logger.info(`ipcMain handle ${IpcChannel.GITHUB_SHOW_USER_CODE_INPUT_WINDOW}`);
         return await this.githubAuthService.showUserCodeInputWindow();
       }
     );

--- a/src/main/ipc/GitHubAuthServiceHandlerImpl.ts
+++ b/src/main/ipc/GitHubAuthServiceHandlerImpl.ts
@@ -33,6 +33,11 @@ export class GitHubAuthServiceHandlerImpl implements IIpcHandlerInitializer {
       }
     );
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    ipcMain.handle(IpcChannel.GITHUB_ABORT_POLLING, async (_event: IpcMainInvokeEvent) => {
+      logger.info(`ipcMain handle ${IpcChannel.GITHUB_ABORT_POLLING}`);
+      return await this.githubAuthService.abortPolling();
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ipcMain.handle(IpcChannel.GITHUB_GET_ACCESS_TOKEN, async (_event: IpcMainInvokeEvent) => {
       logger.info(`ipcMain handle ${IpcChannel.GITHUB_GET_ACCESS_TOKEN}`);
       return await this.githubAuthService.getAccessToken();

--- a/src/main/services/GitHubAuthServiceImpl.ts
+++ b/src/main/services/GitHubAuthServiceImpl.ts
@@ -4,9 +4,8 @@ import type { ICredentialsStoreService } from './ICredentialsStoreService';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../types';
 import type { IUserDetailsService } from './IUserDetailsService';
-import { BaseClient, DeviceFlowHandle, Issuer } from 'openid-client';
+import { BaseClient, DeviceFlowHandle, DeviceFlowPollOptions, Issuer } from 'openid-client';
 import { DateUtil } from '@shared/utils/DateUtil';
-import { TimerManager } from '@shared/utils/TimerManager';
 import { IpcChannel } from '@shared/constants';
 import { IpcService } from './IpcService';
 import { IDeviceFlowAuthService } from './IDeviceFlowAuthService';
@@ -66,6 +65,7 @@ export class GitHubAuthServiceImpl implements IDeviceFlowAuthService {
   private authWindow?: BrowserWindow;
   private verification_uri?: string;
   private _client?: BaseClient;
+  private pollingAbortController?: AbortController;
 
   private scope = ['repo', 'read:user'];
 
@@ -76,8 +76,6 @@ export class GitHubAuthServiceImpl implements IDeviceFlowAuthService {
     private readonly githubCredentialsService: ICredentialsStoreService<GitHubCredentials>,
     @inject(TYPES.IpcService)
     private readonly ipcService: IpcService,
-    @inject(TYPES.TimerManager)
-    private readonly timerManager: TimerManager,
     @inject(TYPES.DateUtil)
     private readonly dateUtil: DateUtil
   ) {}
@@ -142,20 +140,20 @@ export class GitHubAuthServiceImpl implements IDeviceFlowAuthService {
    */
   private async pollTokenRequest(
     handle: DeviceFlowHandle,
-    interval: number = 5 * 1000
+    interval: number = 5 * 1000,
+    options?: DeviceFlowPollOptions
   ): Promise<string> {
-    const timer = this.timerManager.get(GitHubAuthServiceImpl.TIMER_NAME);
-    timer.clear();
     if (handle.expired()) {
       throw new Error('expired!');
     }
 
     await new Promise<void>((resolve) => {
-      timer.addTimeout(resolve, interval);
+      // `handle.poll()`の内部で5秒待つ処理があるため、待ち時間を5秒引いてよい
+      setTimeout(resolve, Math.min(interval - 5 * 1000, 0));
     });
 
     // ここの`handle.poll()`はポーリング処理ではなく単にトークンリクエストを送る関数として使っている。
-    const tokenSet = (await handle.poll()) as GitHubTokenResponse;
+    const tokenSet = (await handle.poll(options)) as GitHubTokenResponse;
 
     switch (tokenSet.error) {
       case undefined:
@@ -165,11 +163,11 @@ export class GitHubAuthServiceImpl implements IDeviceFlowAuthService {
           throw new Error('access_token is missing.');
         }
       case GitHubDeviceFlowErrorCode.AUTHORIZATION_PENDING: {
-        return this.pollTokenRequest(handle, 5 * 1000);
+        return this.pollTokenRequest(handle, 5 * 1000, options);
       }
       case GitHubDeviceFlowErrorCode.SLOW_DOWN: {
         const newInterval = tokenSet?.interval ?? interval + 5 * 1000;
-        return this.pollTokenRequest(handle, newInterval);
+        return this.pollTokenRequest(handle, newInterval, options);
       }
       default:
         // `tokenSet`に`error`が含まれる場合、`error_description`や`error_uri`も含まれるはずなので、`tokenSet`をそのまま出力する。
@@ -178,12 +176,16 @@ export class GitHubAuthServiceImpl implements IDeviceFlowAuthService {
   }
 
   private async fetchCredentials(handle: DeviceFlowHandle): Promise<GitHubCredentials> {
+    this.pollingAbortController = new AbortController();
+    const { signal } = this.pollingAbortController;
     // 本来であれば1回目のトークンリクエストの`interval`の値は`client.deviceAuthorization`でのレスポンスの値を用いるのが正しい。
     // しかし、openid-clientの`DeviceFlowHandle`ではこの値がプライベートになっているため、ポーリングを独自に実装するとこれを利用するのが難しい。
     // そのため、デフォルトの5秒を用いる。
     // 仮に`interval`の値が誤っていたとしても、`slow_down`のエラーレスポンスで正しい`interval`が返ってくるので、2回目以降は正しい処理になる
-    const access_token = await this.pollTokenRequest(handle);
+    const interval = 5 * 1000;
+    const access_token = await this.pollTokenRequest(handle, interval, { signal });
 
+    this.pollingAbortController = undefined;
     const client = await this.getClient();
     const userinfo = (await client.userinfo(access_token)) as GitHubUserInfoResponse;
     return {
@@ -202,6 +204,10 @@ export class GitHubAuthServiceImpl implements IDeviceFlowAuthService {
    */
   async authenticate(): Promise<string> {
     if (logger.isDebugEnabled()) logger.debug(`authenticate`);
+
+    // ポーリング処理が行われている場合は、それを中断する
+    await this.abortPolling();
+
     const accessToken = await this.getAccessToken();
     if (accessToken) {
       return accessToken;
@@ -242,11 +248,24 @@ export class GitHubAuthServiceImpl implements IDeviceFlowAuthService {
       this.authWindow.loadURL(this.verification_uri);
       this.authWindow.show();
 
+      if (this.pollingAbortController) {
+        this.pollingAbortController.signal.addEventListener('abort', () => {
+          this.closeAuthWindow();
+        });
+      }
+
       // windowが閉じられたかどうかを確認する
       this.authWindow.on('closed', () => {
         resolve();
       });
     });
+  }
+
+  async abortPolling(): Promise<void> {
+    if (this.pollingAbortController) {
+      this.pollingAbortController.abort();
+      this.pollingAbortController = undefined;
+    }
   }
 
   async revoke(): Promise<void> {

--- a/src/main/services/GitHubAuthServiceImpl.ts
+++ b/src/main/services/GitHubAuthServiceImpl.ts
@@ -222,23 +222,31 @@ export class GitHubAuthServiceImpl implements IDeviceFlowAuthService {
     }
   }
 
-  async showUserCodeInputWindow(): Promise<void> {
-    if (!this.verification_uri) {
-      throw Error(`verification_uri was not found.`);
-    }
-    this.closeAuthWindow();
-    this.authWindow = new BrowserWindow({
-      width: 612,
-      height: 850,
-      show: false,
-      webPreferences: {
-        nodeIntegration: false,
-        contextIsolation: true,
-      },
-    });
+  showUserCodeInputWindow(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (!this.verification_uri) {
+        reject(new Error(`verification_uri was not found.`));
+        return;
+      }
+      this.closeAuthWindow();
+      this.authWindow = new BrowserWindow({
+        width: 612,
+        height: 850,
+        show: false,
+        webPreferences: {
+          nodeIntegration: false,
+          contextIsolation: true,
+        },
+      });
 
-    this.authWindow.loadURL(this.verification_uri);
-    this.authWindow.show();
+      this.authWindow.loadURL(this.verification_uri);
+      this.authWindow.show();
+
+      // windowが閉じられたかどうかを確認する
+      this.authWindow.on('closed', () => {
+        resolve();
+      });
+    });
   }
 
   async revoke(): Promise<void> {

--- a/src/main/services/IDeviceFlowAuthService.ts
+++ b/src/main/services/IDeviceFlowAuthService.ts
@@ -2,5 +2,6 @@ export interface IDeviceFlowAuthService {
   getAccessToken(): Promise<string | null>;
   authenticate(): Promise<string>;
   showUserCodeInputWindow(): Promise<void>;
+  abortPolling(): Promise<void>;
   revoke(): Promise<void>;
 }

--- a/src/main/services/OverlapEventMergeServiceImpl.ts
+++ b/src/main/services/OverlapEventMergeServiceImpl.ts
@@ -59,7 +59,7 @@ export class OverlapEventMergeServiceImpl implements IOverlapEventMergeService {
       const mergedIntervals = this.mergeOverlapIntervals(
         targetEvents.map((event: EventEntry): Interval => {
           if (event.start.dateTime == null || event.end.dateTime == null) {
-            throw Error();
+            throw new Error();
           }
           return { start: event.start.dateTime, end: event.end.dateTime };
         })

--- a/src/renderer/src/components/settings/AccountSetting.tsx
+++ b/src/renderer/src/components/settings/AccountSetting.tsx
@@ -2,7 +2,7 @@ import rendererContainer from '@renderer/inversify.config';
 import { Grid, Paper, Alert, Button, FormLabel, TextField } from '@mui/material';
 import { useGoogleAuth } from '@renderer/hooks/useGoogleAuth';
 import { useGitHubAuth } from '@renderer/hooks/useGitHubAuth';
-import { Controller, SubmitHandler, useForm } from 'react-hook-form';
+import { SubmitHandler, useForm } from 'react-hook-form';
 import { useContext, useEffect } from 'react';
 import AppContext from '../AppContext';
 import { useUserPreference } from '@renderer/hooks/useUserPreference';
@@ -22,7 +22,6 @@ export const AccountSetting = (): JSX.Element => {
   const { userPreference, loading } = useUserPreference();
 
   const {
-    control,
     handleSubmit,
     formState: { errors: formErrors },
     reset,
@@ -191,7 +190,8 @@ export const AccountSetting = (): JSX.Element => {
                 </Grid>
               </Paper>
             </Grid>
-            <Grid item xs={12}>
+            {/* OPENAI API KEYは現状使われていないためコメントアウト */}
+            {/* <Grid item xs={12}>
               <Paper variant="outlined" sx={{ padding: 2 }}>
                 <Controller
                   name={`openAiKey`}
@@ -214,7 +214,7 @@ export const AccountSetting = (): JSX.Element => {
                   )}
                 />
               </Paper>
-            </Grid>
+            </Grid> */}
           </Grid>
         </Paper>
       </SettingFormBox>

--- a/src/renderer/src/components/settings/AccountSetting.tsx
+++ b/src/renderer/src/components/settings/AccountSetting.tsx
@@ -48,6 +48,7 @@ export const AccountSetting = (): JSX.Element => {
     isAuthenticated: isGitHubAuthenticated,
     authError: githubAuthError,
     userCode: githubUserCode,
+    isOpenUserCodeWindow: isOpenGitHubUserCodeWindow,
     handleAuth: handleGitHubAuth,
     handleShowUserCodeInputWindow: handleGitHubShowWindow,
     handleRevoke: handleGitHubRevoke,
@@ -163,6 +164,7 @@ export const AccountSetting = (): JSX.Element => {
                                 <Button
                                   variant="contained"
                                   color="primary"
+                                  disabled={isOpenGitHubUserCodeWindow}
                                   onClick={handleGitHubShowWindow}
                                 >
                                   コードを入力する

--- a/src/renderer/src/hooks/useGitHubAuth.ts
+++ b/src/renderer/src/hooks/useGitHubAuth.ts
@@ -33,6 +33,10 @@ const useGitHubAuth = (): UseGitHubAuthResult => {
       setIsAuthenticated(accessToken !== null);
     };
     load();
+    // コンポーネントがアンマウントされたときにトークンリクエストのポーリングを止める
+    return () => {
+      authProxy.abortPolling();
+    };
   }, [authProxy]);
 
   useEffect(() => {
@@ -47,7 +51,7 @@ const useGitHubAuth = (): UseGitHubAuthResult => {
     return () => {
       unsubscribe();
     };
-  });
+  }, []);
 
   const handleAuth = async (): Promise<void> => {
     try {

--- a/src/renderer/src/hooks/useGitHubAuth.ts
+++ b/src/renderer/src/hooks/useGitHubAuth.ts
@@ -9,6 +9,7 @@ type UseGitHubAuthResult = {
   isAuthenticated: boolean | null;
   authError: string | null;
   userCode: string | null;
+  isOpenUserCodeWindow: boolean;
   handleAuth: () => Promise<void>;
   handleShowUserCodeInputWindow: () => Promise<void>;
   handleRevoke: () => Promise<void>;
@@ -22,6 +23,7 @@ const useGitHubAuth = (): UseGitHubAuthResult => {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
   const [userCode, setUserCode] = useState<string | null>(null);
+  const [isOpenUserCodeWindow, setUserCodeWindowOpen] = useState<boolean>(false);
   const authProxy = rendererContainer.get<IDeviceFlowAuthProxy>(TYPES.GitHubAuthProxy);
 
   useEffect(() => {
@@ -67,7 +69,13 @@ const useGitHubAuth = (): UseGitHubAuthResult => {
     }
   };
   const handleShowUserCodeInputWindow = async (): Promise<void> => {
-    await authProxy.showUserCodeInputWindow();
+    setUserCodeWindowOpen(true);
+    try {
+      await authProxy.showUserCodeInputWindow();
+    } catch (error) {
+      logger.error('Error during user code input', error);
+    }
+    setUserCodeWindowOpen(false);
   };
   const handleRevoke = async (): Promise<void> => {
     try {
@@ -85,6 +93,7 @@ const useGitHubAuth = (): UseGitHubAuthResult => {
     isAuthenticated,
     authError,
     userCode,
+    isOpenUserCodeWindow,
     handleAuth,
     handleShowUserCodeInputWindow,
     handleRevoke,

--- a/src/renderer/src/services/GitHubAuthProxyImpl.ts
+++ b/src/renderer/src/services/GitHubAuthProxyImpl.ts
@@ -19,6 +19,10 @@ export class GitHubAuthProxyImpl implements IDeviceFlowAuthProxy {
     if (logger.isDebugEnabled()) logger.debug(`GitHubAuthProxyImpl showUserCodeInputWindow`);
     return await window.electron.ipcRenderer.invoke(IpcChannel.GITHUB_SHOW_USER_CODE_INPUT_WINDOW);
   }
+  async abortPolling(): Promise<void> {
+    if (logger.isDebugEnabled()) logger.debug(`GitHubAuthProxyImpl abortPolling`);
+    return await window.electron.ipcRenderer.invoke(IpcChannel.GITHUB_ABORT_POLLING);
+  }
   async revoke(): Promise<void> {
     if (logger.isDebugEnabled()) logger.debug(`GitHubAuthProxyImpl revoke`);
     return await window.electron.ipcRenderer.invoke(IpcChannel.GITHUB_REVOKE);

--- a/src/renderer/src/services/GitHubAuthProxyImpl.ts
+++ b/src/renderer/src/services/GitHubAuthProxyImpl.ts
@@ -16,7 +16,7 @@ export class GitHubAuthProxyImpl implements IDeviceFlowAuthProxy {
     return await window.electron.ipcRenderer.invoke(IpcChannel.GITHUB_AUTHENTICATE);
   }
   async showUserCodeInputWindow(): Promise<void> {
-    console.log(`GitHubAuthProxyImpl showUserCodeInputWindow`);
+    if (logger.isDebugEnabled()) logger.debug(`GitHubAuthProxyImpl showUserCodeInputWindow`);
     return await window.electron.ipcRenderer.invoke(IpcChannel.GITHUB_SHOW_USER_CODE_INPUT_WINDOW);
   }
   async revoke(): Promise<void> {

--- a/src/renderer/src/services/IDeviceFlowAuthProxy.ts
+++ b/src/renderer/src/services/IDeviceFlowAuthProxy.ts
@@ -2,5 +2,6 @@ export interface IDeviceFlowAuthProxy {
   getAccessToken(): Promise<string | null>;
   authenticate(): Promise<string>;
   showUserCodeInputWindow(): Promise<void>;
+  abortPolling(): Promise<void>;
   revoke(): Promise<void>;
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -7,6 +7,7 @@ export enum IpcChannel {
 
   GITHUB_AUTHENTICATE = 'github_authenticate',
   GITHUB_SHOW_USER_CODE_INPUT_WINDOW = 'github_show_user_code_input_window',
+  GITHUB_ABORT_POLLING = 'github_abort_polling',
   GITHUB_GET_ACCESS_TOKEN = 'github_get_access_token',
   GITHUB_REVOKE = 'github_revoke',
 

--- a/src/shared/data/UserPreference.ts
+++ b/src/shared/data/UserPreference.ts
@@ -31,7 +31,7 @@ export interface UserPreference {
   notifyBeforePomodoroComplete: NotificationSettings;
 
   theme?: string;
-  openAiKey?: string;
+  // openAiKey?: string;
 
   updated: Date;
 }


### PR DESCRIPTION
## チケット
#234 

## 実装内容
- ユーザーコード入力画面を表示する関数で、閉じたことを検出できるように変更
- ユーザーコードを開いたタイミングで「コードを入力する」ボタンを無効化し、閉じたタイミングで有効化する
- ログ出力の修正