### PR TITLE
fix: 機能テストバグ対応 - GitHub認証のポーリング処理が二重に行えてしまう

### DIFF
--- a/src/main/ipc/GitHubAuthServiceHandlerImpl.ts
+++ b/src/main/ipc/GitHubAuthServiceHandlerImpl.ts
@@ -33,6 +33,11 @@ export class GitHubAuthServiceHandlerImpl implements IIpcHandlerInitializer {
       }
     );
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    ipcMain.handle(IpcChannel.GITHUB_ABORT_POLLING, async (_event: IpcMainInvokeEvent) => {
+      logger.info(`ipcMain handle ${IpcChannel.GITHUB_ABORT_POLLING}`);
+      return await this.githubAuthService.abortPolling();
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ipcMain.handle(IpcChannel.GITHUB_GET_ACCESS_TOKEN, async (_event: IpcMainInvokeEvent) => {
       logger.info(`ipcMain handle ${IpcChannel.GITHUB_GET_ACCESS_TOKEN}`);
       return await this.githubAuthService.getAccessToken();

--- a/src/main/services/GitHubAuthServiceImpl.ts
+++ b/src/main/services/GitHubAuthServiceImpl.ts
@@ -248,6 +248,12 @@ export class GitHubAuthServiceImpl implements IDeviceFlowAuthService {
       this.authWindow.loadURL(this.verification_uri);
       this.authWindow.show();
 
+      if (this.pollingAbortController) {
+        this.pollingAbortController.signal.addEventListener('abort', () => {
+          this.closeAuthWindow();
+        });
+      }
+
       // windowが閉じられたかどうかを確認する
       this.authWindow.on('closed', () => {
         resolve();

--- a/src/main/services/IDeviceFlowAuthService.ts
+++ b/src/main/services/IDeviceFlowAuthService.ts
@@ -2,5 +2,6 @@ export interface IDeviceFlowAuthService {
   getAccessToken(): Promise<string | null>;
   authenticate(): Promise<string>;
   showUserCodeInputWindow(): Promise<void>;
+  abortPolling(): Promise<void>;
   revoke(): Promise<void>;
 }

--- a/src/renderer/src/components/settings/AccountSetting.tsx
+++ b/src/renderer/src/components/settings/AccountSetting.tsx
@@ -2,7 +2,7 @@ import rendererContainer from '@renderer/inversify.config';
 import { Grid, Paper, Alert, Button, FormLabel, TextField } from '@mui/material';
 import { useGoogleAuth } from '@renderer/hooks/useGoogleAuth';
 import { useGitHubAuth } from '@renderer/hooks/useGitHubAuth';
-import { Controller, SubmitHandler, useForm } from 'react-hook-form';
+import { SubmitHandler, useForm } from 'react-hook-form';
 import { useContext, useEffect } from 'react';
 import AppContext from '../AppContext';
 import { useUserPreference } from '@renderer/hooks/useUserPreference';
@@ -22,7 +22,6 @@ export const AccountSetting = (): JSX.Element => {
   const { userPreference, loading } = useUserPreference();
 
   const {
-    control,
     handleSubmit,
     formState: { errors: formErrors },
     reset,
@@ -191,7 +190,8 @@ export const AccountSetting = (): JSX.Element => {
                 </Grid>
               </Paper>
             </Grid>
-            <Grid item xs={12}>
+            {/* OPENAI API KEYは現状使われていないためコメントアウト */}
+            {/* <Grid item xs={12}>
               <Paper variant="outlined" sx={{ padding: 2 }}>
                 <Controller
                   name={`openAiKey`}
@@ -214,7 +214,7 @@ export const AccountSetting = (): JSX.Element => {
                   )}
                 />
               </Paper>
-            </Grid>
+            </Grid> */}
           </Grid>
         </Paper>
       </SettingFormBox>

--- a/src/renderer/src/hooks/useGitHubAuth.ts
+++ b/src/renderer/src/hooks/useGitHubAuth.ts
@@ -33,6 +33,10 @@ const useGitHubAuth = (): UseGitHubAuthResult => {
       setIsAuthenticated(accessToken !== null);
     };
     load();
+    // コンポーネントがアンマウントされたときにトークンリクエストのポーリングを止める
+    return () => {
+      authProxy.abortPolling();
+    };
   }, [authProxy]);
 
   useEffect(() => {
@@ -47,7 +51,7 @@ const useGitHubAuth = (): UseGitHubAuthResult => {
     return () => {
       unsubscribe();
     };
-  });
+  }, []);
 
   const handleAuth = async (): Promise<void> => {
     try {

--- a/src/renderer/src/services/GitHubAuthProxyImpl.ts
+++ b/src/renderer/src/services/GitHubAuthProxyImpl.ts
@@ -19,6 +19,10 @@ export class GitHubAuthProxyImpl implements IDeviceFlowAuthProxy {
     if (logger.isDebugEnabled()) logger.debug(`GitHubAuthProxyImpl showUserCodeInputWindow`);
     return await window.electron.ipcRenderer.invoke(IpcChannel.GITHUB_SHOW_USER_CODE_INPUT_WINDOW);
   }
+  async abortPolling(): Promise<void> {
+    if (logger.isDebugEnabled()) logger.debug(`GitHubAuthProxyImpl abortPolling`);
+    return await window.electron.ipcRenderer.invoke(IpcChannel.GITHUB_ABORT_POLLING);
+  }
   async revoke(): Promise<void> {
     if (logger.isDebugEnabled()) logger.debug(`GitHubAuthProxyImpl revoke`);
     return await window.electron.ipcRenderer.invoke(IpcChannel.GITHUB_REVOKE);

--- a/src/renderer/src/services/IDeviceFlowAuthProxy.ts
+++ b/src/renderer/src/services/IDeviceFlowAuthProxy.ts
@@ -2,5 +2,6 @@ export interface IDeviceFlowAuthProxy {
   getAccessToken(): Promise<string | null>;
   authenticate(): Promise<string>;
   showUserCodeInputWindow(): Promise<void>;
+  abortPolling(): Promise<void>;
   revoke(): Promise<void>;
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -7,6 +7,7 @@ export enum IpcChannel {
 
   GITHUB_AUTHENTICATE = 'github_authenticate',
   GITHUB_SHOW_USER_CODE_INPUT_WINDOW = 'github_show_user_code_input_window',
+  GITHUB_ABORT_POLLING = 'github_abort_polling',
   GITHUB_GET_ACCESS_TOKEN = 'github_get_access_token',
   GITHUB_REVOKE = 'github_revoke',
 

--- a/src/shared/data/UserPreference.ts
+++ b/src/shared/data/UserPreference.ts
@@ -31,7 +31,7 @@ export interface UserPreference {
   notifyBeforePomodoroComplete: NotificationSettings;
 
   theme?: string;
-  openAiKey?: string;
+  // openAiKey?: string;
 
   updated: Date;
 }


### PR DESCRIPTION
## チケット
#235 

## 実装内容
- ポーリングの中断機能を実装
- コンポーネントのアンマウント時にポーリングを中断する
- ポーリングの待ち時間を調整
- openAiKeyの項目をコメントアウト