### PR TITLE
fix: 機能テストバグ対応 - プロジェクトなしを選択した際にフォームの表示が異なる

### DIFF
--- a/src/main/ipc/TaskHandlerImpl.ts
+++ b/src/main/ipc/TaskHandlerImpl.ts
@@ -19,9 +19,13 @@ export class TaskHandlerImpl implements IIpcHandlerInitializer {
   ) {}
 
   init(): void {
-    ipcMain.handle(IpcChannel.TASK_LIST, async (_event, pageRequest, projectId) => {
+    ipcMain.handle(IpcChannel.TASK_LIST, async (_event, pageRequest, listMode, projectId) => {
       return handleDatabaseOperation(async (): Promise<PageResponse<Task>> => {
-        const page = await this.taskService.list(Pageable.fromPageRequest(pageRequest), projectId);
+        const page = await this.taskService.list(
+          Pageable.fromPageRequest(pageRequest),
+          listMode,
+          projectId
+        );
         return page.toPageResponse();
       });
     });

--- a/src/main/ipc/TaskHandlerImpl.ts
+++ b/src/main/ipc/TaskHandlerImpl.ts
@@ -19,16 +19,19 @@ export class TaskHandlerImpl implements IIpcHandlerInitializer {
   ) {}
 
   init(): void {
-    ipcMain.handle(IpcChannel.TASK_LIST, async (_event, pageRequest, listMode, projectId) => {
-      return handleDatabaseOperation(async (): Promise<PageResponse<Task>> => {
-        const page = await this.taskService.list(
-          Pageable.fromPageRequest(pageRequest),
-          listMode,
-          projectId
-        );
-        return page.toPageResponse();
-      });
-    });
+    ipcMain.handle(
+      IpcChannel.TASK_LIST,
+      async (_event, pageRequest, isFilterByProject, projectId) => {
+        return handleDatabaseOperation(async (): Promise<PageResponse<Task>> => {
+          const page = await this.taskService.list(
+            Pageable.fromPageRequest(pageRequest),
+            isFilterByProject,
+            projectId
+          );
+          return page.toPageResponse();
+        });
+      }
+    );
 
     ipcMain.handle(IpcChannel.TASK_GET, async (_event, id) => {
       return handleDatabaseOperation(async (): Promise<Task> => {

--- a/src/main/services/ITaskService.ts
+++ b/src/main/services/ITaskService.ts
@@ -2,7 +2,7 @@ import { Page, Pageable } from '@shared/data/Page';
 import { Task } from '@shared/data/Task';
 
 export interface ITaskService {
-  list(pageable: Pageable, listMode?: string, projectId?: string): Promise<Page<Task>>;
+  list(pageable: Pageable, isFilterByProject?: boolean, projectId?: string): Promise<Page<Task>>;
   get(id: string): Promise<Task>;
   getUncompletedByPriority(): Promise<Task[]>;
   save(task: Task): Promise<Task>;

--- a/src/main/services/ITaskService.ts
+++ b/src/main/services/ITaskService.ts
@@ -2,7 +2,7 @@ import { Page, Pageable } from '@shared/data/Page';
 import { Task } from '@shared/data/Task';
 
 export interface ITaskService {
-  list(pageable: Pageable, projectId?: string): Promise<Page<Task>>;
+  list(pageable: Pageable, listMode?: string, projectId?: string): Promise<Page<Task>>;
   get(id: string): Promise<Task>;
   getUncompletedByPriority(): Promise<Task[]>;
   save(task: Task): Promise<Task>;

--- a/src/main/services/TaskServiceImpl.ts
+++ b/src/main/services/TaskServiceImpl.ts
@@ -1,6 +1,6 @@
 import { TYPES } from '@main/types';
 import { Page, Pageable } from '@shared/data/Page';
-import { Task, TASK_STATUS } from '@shared/data/Task';
+import { PROJECT_FILTER, Task, TASK_STATUS } from '@shared/data/Task';
 import { UniqueConstraintError } from '@shared/errors/UniqueConstraintError';
 import { inject, injectable } from 'inversify';
 import { DataSource } from './DataSource';
@@ -37,14 +37,15 @@ export class TaskServiceImpl implements ITaskService {
    * Task のリストを取得
    *
    * @param {Pageable} pageable - ページング情報を含むオブジェクト
-   * @param {string} [projectId=''] - プロジェクトID、指定がない場合は全体から取得
+   * @param {string} listMode - リストの出力モード
+   * @param {string} projectId - プロジェクトID
    * @returns {Promise<Page<Task>>} - ページを含むタスクオブジェクト
    */
-  async list(pageable: Pageable, projectId = ''): Promise<Page<Task>> {
+  async list(pageable: Pageable, listMode = '', projectId = ''): Promise<Page<Task>> {
     const userId = await this.userDetailsService.getUserId();
     const query: taskQuery = { minr_user_id: userId };
     // projectId が無い場合はフィルタリングを行わないため taskQuery に設定しない
-    if (projectId !== '') {
+    if (listMode == PROJECT_FILTER) {
       query.projectId = projectId;
     }
     const sort = {};

--- a/src/main/services/TaskServiceImpl.ts
+++ b/src/main/services/TaskServiceImpl.ts
@@ -1,6 +1,6 @@
 import { TYPES } from '@main/types';
 import { Page, Pageable } from '@shared/data/Page';
-import { PROJECT_FILTER, Task, TASK_STATUS } from '@shared/data/Task';
+import { Task, TASK_STATUS } from '@shared/data/Task';
 import { UniqueConstraintError } from '@shared/errors/UniqueConstraintError';
 import { inject, injectable } from 'inversify';
 import { DataSource } from './DataSource';
@@ -37,15 +37,15 @@ export class TaskServiceImpl implements ITaskService {
    * Task のリストを取得
    *
    * @param {Pageable} pageable - ページング情報を含むオブジェクト
-   * @param {string} listMode - リストの出力モード
+   * @param {boolean} isFilterByProject - プロジェクトIDによるフィルターの有無
    * @param {string} projectId - プロジェクトID
    * @returns {Promise<Page<Task>>} - ページを含むタスクオブジェクト
    */
-  async list(pageable: Pageable, listMode = '', projectId = ''): Promise<Page<Task>> {
+  async list(pageable: Pageable, isFilterByProject = false, projectId = ''): Promise<Page<Task>> {
     const userId = await this.userDetailsService.getUserId();
     const query: taskQuery = { minr_user_id: userId };
     // projectId が無い場合はフィルタリングを行わないため taskQuery に設定しない
-    if (listMode == PROJECT_FILTER) {
+    if (isFilterByProject) {
       query.projectId = projectId;
     }
     const sort = {};

--- a/src/renderer/src/components/pattern/PatternEdit.tsx
+++ b/src/renderer/src/components/pattern/PatternEdit.tsx
@@ -51,6 +51,7 @@ export const PatternEdit = ({
     reset,
     formState: { errors: formErrors },
     setError,
+    setValue,
   } = useForm<PatternFormData>();
 
   useEffect(() => {
@@ -71,7 +72,6 @@ export const PatternEdit = ({
   const projectId = useWatch({
     control,
     name: `projectId`,
-    defaultValue: 'NULL',
   });
 
   const handleDialogSubmit = async (data: PatternFormData): Promise<void> => {
@@ -189,7 +189,13 @@ export const PatternEdit = ({
             name={`projectId`}
             control={control}
             render={({ field: { onChange, value } }): JSX.Element => (
-              <ProjectDropdownComponent value={value} onChange={onChange} />
+              <ProjectDropdownComponent
+                value={value}
+                onChange={(newValue: string): void => {
+                  onChange(newValue);
+                  setValue('taskId', '');
+                }}
+              />
             )}
           />
         </Grid>
@@ -220,7 +226,11 @@ export const PatternEdit = ({
             name="taskId"
             control={control}
             render={({ field }): React.ReactElement => (
-              <TaskDropdownComponent onChange={field.onChange} projectId={projectId} />
+              <TaskDropdownComponent
+                value={field.value}
+                onChange={field.onChange}
+                projectId={projectId}
+              />
             )}
           />
         </Grid>

--- a/src/renderer/src/components/project/ProjectDropdownComponent.tsx
+++ b/src/renderer/src/components/project/ProjectDropdownComponent.tsx
@@ -102,7 +102,7 @@ export const ProjectDropdownComponent = ({
           },
         }}
       >
-        <MenuItem value="NULL">
+        <MenuItem value="">
           <em>プロジェクトなし</em>
         </MenuItem>
         {sorted.map((project) => (

--- a/src/renderer/src/components/task/TaskDropdownComponent.tsx
+++ b/src/renderer/src/components/task/TaskDropdownComponent.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, MenuItem, TextField } from '@mui/material';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
-import { useTaskMap } from '@renderer/hooks/useTaskMap';
+import { useTaskMapFilteredProject } from '@renderer/hooks/useTaskMap';
 import { Task } from '@shared/data/Task';
 import { useEffect, useState } from 'react';
 import { TaskEdit } from './TaskEdit';
@@ -37,8 +37,8 @@ export const TaskDropdownComponent = ({
   value,
   projectId,
 }: TaskDropdownComponentProps): JSX.Element => {
-  const [selectedValue, setSelectedValue] = useState<string | undefined | null>(value || '');
-  const { taskMap, isLoading, refresh } = useTaskMap(projectId);
+  const [selectedValue, setSelectedValue] = useState<string>(value || '');
+  const { taskMap, isLoading, refresh } = useTaskMapFilteredProject(projectId);
   const [isDialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {

--- a/src/renderer/src/components/timeTable/EventEntryForm.tsx
+++ b/src/renderer/src/components/timeTable/EventEntryForm.tsx
@@ -420,7 +420,7 @@ const EventEntryForm = ({
                         <TaskDropdownComponent
                           value={value}
                           onChange={onChange}
-                          projectId={projectId || 'NULL'}
+                          projectId={projectId || ''}
                         />
                       )}
                     />

--- a/src/renderer/src/hooks/useTaskMap.ts
+++ b/src/renderer/src/hooks/useTaskMap.ts
@@ -2,7 +2,7 @@ import rendererContainer from '@renderer/inversify.config';
 import { ITaskProxy } from '@renderer/services/ITaskProxy';
 import { TYPES } from '@renderer/types';
 import { Pageable } from '@shared/data/Page';
-import { Task } from '@shared/data/Task';
+import { PROJECT_FILTER, Task } from '@shared/data/Task';
 import { useQuery } from 'react-query';
 import { CacheKey } from './cacheKey';
 import { getLogger } from '@renderer/utils/LoggerUtil';
@@ -22,14 +22,36 @@ const logger = getLogger('useTaskMap');
 /**
  * タスクのマップを取得するフック
  *
- * @param {string} projectId - プロジェクトID、指定がない場合は全体から取得
  * @returns {UseTaskMapResult}
  */
-export const useTaskMap = (projectId = ''): UseTaskMapResult => {
+export const useTaskMap = (): UseTaskMapResult => {
   if (logger.isDebugEnabled()) logger.debug('useTaskMap');
+  const { data, error, isLoading, refetch } = useQuery([CacheKey.TASKS], () => fetchTasks(), {
+    staleTime: 0,
+    cacheTime: 0,
+  });
+  const map = data ?? EMPTY_MAP;
+
+  // 内部で refetch をラップする。
+  // これにより refetch の戻り値の型が露出させない。機能的な意味はない。
+  const refresh = async (): Promise<void> => {
+    await refetch();
+  };
+
+  return { taskMap: map, refresh, error, isLoading };
+};
+
+/**
+ * プロジェクトIDでフィルタリングしたタスクのマップを取得するフック
+ *
+ * @param {string} projectId - プロジェクトID
+ * @returns {UseTaskMapResult}
+ */
+export const useTaskMapFilteredProject = (projectId: string): UseTaskMapResult => {
+  if (logger.isDebugEnabled()) logger.debug('useTaskMapFilteredProject');
   const { data, error, isLoading, refetch } = useQuery(
     [CacheKey.TASKS, projectId],
-    () => fetchTasks(projectId),
+    () => fetchTasks(PROJECT_FILTER, projectId),
     {
       staleTime: 0,
       cacheTime: 0,
@@ -49,13 +71,14 @@ export const useTaskMap = (projectId = ''): UseTaskMapResult => {
 /**
  * タスクを取得
  *
+ * @param {string} listMode - リストの出力モード
  * @param {string} projectId - プロジェクトID
  * @returns {Promise<Map<string, Task>>} - タスクのマップオブジェクト
  */
-const fetchTasks = async (projectId: string): Promise<Map<string, Task>> => {
+const fetchTasks = async (listMode = '', projectId = ''): Promise<Map<string, Task>> => {
   if (logger.isDebugEnabled()) logger.debug('fetchTasks');
   const proxy = rendererContainer.get<ITaskProxy>(TYPES.TaskProxy);
-  const result = await proxy.list(PAGEABLE, projectId);
+  const result = await proxy.list(PAGEABLE, listMode, projectId);
   const taskMap = new Map<string, Task>();
   result.content.forEach((task) => {
     taskMap.set(task.id, task);

--- a/src/renderer/src/hooks/useTaskMap.ts
+++ b/src/renderer/src/hooks/useTaskMap.ts
@@ -2,7 +2,7 @@ import rendererContainer from '@renderer/inversify.config';
 import { ITaskProxy } from '@renderer/services/ITaskProxy';
 import { TYPES } from '@renderer/types';
 import { Pageable } from '@shared/data/Page';
-import { PROJECT_FILTER, Task } from '@shared/data/Task';
+import { Task } from '@shared/data/Task';
 import { useQuery } from 'react-query';
 import { CacheKey } from './cacheKey';
 import { getLogger } from '@renderer/utils/LoggerUtil';
@@ -51,7 +51,7 @@ export const useTaskMapFilteredProject = (projectId: string): UseTaskMapResult =
   if (logger.isDebugEnabled()) logger.debug('useTaskMapFilteredProject');
   const { data, error, isLoading, refetch } = useQuery(
     [CacheKey.TASKS, projectId],
-    () => fetchTasks(PROJECT_FILTER, projectId),
+    () => fetchTasks(true, projectId),
     {
       staleTime: 0,
       cacheTime: 0,
@@ -71,14 +71,17 @@ export const useTaskMapFilteredProject = (projectId: string): UseTaskMapResult =
 /**
  * タスクを取得
  *
- * @param {string} listMode - リストの出力モード
+ * @param {boolean} isFilterByProject - プロジェクトIDによるフィルターの有無
  * @param {string} projectId - プロジェクトID
  * @returns {Promise<Map<string, Task>>} - タスクのマップオブジェクト
  */
-const fetchTasks = async (listMode = '', projectId = ''): Promise<Map<string, Task>> => {
+const fetchTasks = async (
+  isFilterByProject = false,
+  projectId = ''
+): Promise<Map<string, Task>> => {
   if (logger.isDebugEnabled()) logger.debug('fetchTasks');
   const proxy = rendererContainer.get<ITaskProxy>(TYPES.TaskProxy);
-  const result = await proxy.list(PAGEABLE, listMode, projectId);
+  const result = await proxy.list(PAGEABLE, isFilterByProject, projectId);
   const taskMap = new Map<string, Task>();
   result.content.forEach((task) => {
     taskMap.set(task.id, task);

--- a/src/renderer/src/services/ITaskProxy.ts
+++ b/src/renderer/src/services/ITaskProxy.ts
@@ -3,7 +3,7 @@ import { ICRUDProxy } from './ICRUDProxy';
 import { Page, Pageable } from '@shared/data/Page';
 
 export interface ITaskProxy extends ICRUDProxy<Task> {
-  list(pageable: Pageable, projectId?: string): Promise<Page<Task>>;
+  list(pageable: Pageable, listMode?: string, projectId?: string): Promise<Page<Task>>;
   get(id: string): Promise<Task>;
   save(task: Task): Promise<Task>;
   delete(id: string): Promise<void>;

--- a/src/renderer/src/services/ITaskProxy.ts
+++ b/src/renderer/src/services/ITaskProxy.ts
@@ -3,7 +3,7 @@ import { ICRUDProxy } from './ICRUDProxy';
 import { Page, Pageable } from '@shared/data/Page';
 
 export interface ITaskProxy extends ICRUDProxy<Task> {
-  list(pageable: Pageable, listMode?: string, projectId?: string): Promise<Page<Task>>;
+  list(pageable: Pageable, isFilterByProject?: boolean, projectId?: string): Promise<Page<Task>>;
   get(id: string): Promise<Task>;
   save(task: Task): Promise<Task>;
   delete(id: string): Promise<void>;

--- a/src/renderer/src/services/TaskProxyImpl.ts
+++ b/src/renderer/src/services/TaskProxyImpl.ts
@@ -14,16 +14,16 @@ export class TaskProxyImpl implements ITaskProxy {
    * Taskのリストを取得
    *
    * @param {Pageable} pageable - ページング情報を含むオブジェクト
-   * @param {string} listMode - リストの出力モード
+   * @param {boolean} isFilterByProject - プロジェクトIDによるフィルターの有無
    * @param {string} projectId - プロジェクトID
    * @returns {Promise<Page<Task>>} - ページを含むタスクオブジェクト
    */
-  async list(pageable: Pageable, listMode = '', projectId = ''): Promise<Page<Task>> {
+  async list(pageable: Pageable, isFilterByProject = false, projectId = ''): Promise<Page<Task>> {
     return await handleIpcOperation(async () => {
       const responce = await window.electron.ipcRenderer.invoke(
         IpcChannel.TASK_LIST,
         pageable.toPageRequest(),
-        listMode,
+        isFilterByProject,
         projectId
       );
       return Page.fromPageResponse(responce);

--- a/src/renderer/src/services/TaskProxyImpl.ts
+++ b/src/renderer/src/services/TaskProxyImpl.ts
@@ -14,14 +14,16 @@ export class TaskProxyImpl implements ITaskProxy {
    * Taskのリストを取得
    *
    * @param {Pageable} pageable - ページング情報を含むオブジェクト
-   * @param {string} [projectId=''] - プロジェクトID、指定がない場合は全体から取得
+   * @param {string} listMode - リストの出力モード
+   * @param {string} projectId - プロジェクトID
    * @returns {Promise<Page<Task>>} - ページを含むタスクオブジェクト
    */
-  async list(pageable: Pageable, projectId = ''): Promise<Page<Task>> {
+  async list(pageable: Pageable, listMode = '', projectId = ''): Promise<Page<Task>> {
     return await handleIpcOperation(async () => {
       const responce = await window.electron.ipcRenderer.invoke(
         IpcChannel.TASK_LIST,
         pageable.toPageRequest(),
+        listMode,
         projectId
       );
       return Page.fromPageResponse(responce);

--- a/src/shared/data/Task.ts
+++ b/src/shared/data/Task.ts
@@ -1,3 +1,5 @@
+export const PROJECT_FILTER = 'project_filter';
+
 export enum TASK_STATUS {
   COMPLETED = 'completed',
   UNCOMPLETED = 'uncompleted',


### PR DESCRIPTION
## チケット

#238 

## 対応内容

* Context
    * プロジェクトのドロップダウンが未入力時にテキスト内に入力されている状態のため修正する。
* Decision
    * プロジェクトのドロップダウンにてNULLを空文字に変更する。
    * `Task`の`list`にてプロジェクトのフィルター有りと、無しの切り替え機能を追加する。
* Consequences
    * プロジェクトのドロップダウンにて`プロジェクトなし`を選択したときに`NULL`の文字が入っていたのがテキスト入力の原因。
        * `NULL`を削除すれば表示は他のドロップダウンと同様になる。
    * `Task`の一覧取得には`list`を使用しているが、ドロップダウンも同じく使用しているため、空文字だとプロジェクト未選択時のタスクのドロップダウンで全件が出力されてしまう。
        * タスクのドロップダウンではプロジェクト未選択時にタスクは表示しない仕様。
        * プロジェクトでのフィルターの有無を別途引数で選択するように実装し、空文字でもフィルター有りの検索を行えるように修正する。
