### PR TITLE
fix: 機能テストバグ対応 - ドロップダウンからタスクを追加時にプロジェクトIDを固定値にする

### DIFF
--- a/src/renderer/src/components/project/ProjectDropdownComponent.tsx
+++ b/src/renderer/src/components/project/ProjectDropdownComponent.tsx
@@ -11,10 +11,12 @@ import { getLogger } from '@renderer/utils/LoggerUtil';
  *
  * @property {Function} onChange - プロジェクトが選択されたときに呼び出される関数。
  * @property {string | null} [value] - 初期値または外部から制御される値。オプショナル。
+ * @property {boolean} [isDasabled] - プロジェクトを固定値にするか判定する値。
  */
 interface ProjectDropdownComponentProps {
   onChange: (value: string) => void;
   value?: string | null;
+  isDasabled?: boolean;
 }
 
 const logger = getLogger('ProjectDropdownComponent');
@@ -40,6 +42,7 @@ const logger = getLogger('ProjectDropdownComponent');
 export const ProjectDropdownComponent = ({
   onChange,
   value,
+  isDasabled,
 }: ProjectDropdownComponentProps): JSX.Element => {
   const { projectMap, isLoading, refresh } = useProjectMap();
   const [selectedValue, setSelectedValue] = useState<string | undefined | null>(value || '');
@@ -47,7 +50,8 @@ export const ProjectDropdownComponent = ({
 
   useEffect(() => {
     setSelectedValue(value || '');
-  }, [value]);
+    onChange(value || '');
+  }, [value, onChange]);
 
   // ドロップダウンの値が選択変更されたイベント
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
@@ -92,6 +96,7 @@ export const ProjectDropdownComponent = ({
         onChange={handleChange}
         variant="outlined"
         fullWidth
+        disabled={isDasabled}
         SelectProps={{
           MenuProps: {
             PaperProps: {

--- a/src/renderer/src/components/task/TaskDropdownComponent.tsx
+++ b/src/renderer/src/components/task/TaskDropdownComponent.tsx
@@ -131,6 +131,7 @@ export const TaskDropdownComponent = ({
         <TaskEdit
           isOpen={isDialogOpen}
           taskId={null}
+          projectId={projectId}
           onClose={handleDialogClose}
           onSubmit={handleDialogSubmit}
         />


### PR DESCRIPTION
## チケット

#240 

## 対応内容

* Context
    * 各フォームからのタスク新規追加はタスクドロップダウンを経由してタスク追加に遷移している。
    * ドロップダウンからタスク追加に遷移する際にプロジェクトを固定値にする。
* Decision
    * タスク追加・編集にプロジェクトIDの引数を追加し、プロジェクトの有無で固定値にするかを判定する処理を追加する。
* Consequences
    * 各フォームからのタスク新規追加はタスクドロップダウンを経由してタスク追加に遷移している。
        * `projectId`の有無で、タスク一覧からの完全新規かドロップダウンからのプロジェクト指定新規か判別することができる。
    * タスク追加ではプロジェクトの指定をドロップダウンで行っているが、プロジェクトドロップダウンを修正すると規模が大きくなるため、タスク追加の中にプロジェクトの固定値の処理を追加する。