### PR TITLE
fix: タスクの編集時にプロジェクトが表示されない

### DIFF
--- a/src/renderer/src/components/project/ProjectDropdownComponent.tsx
+++ b/src/renderer/src/components/project/ProjectDropdownComponent.tsx
@@ -11,12 +11,12 @@ import { getLogger } from '@renderer/utils/LoggerUtil';
  *
  * @property {Function} onChange - プロジェクトが選択されたときに呼び出される関数。
  * @property {string | null} [value] - 初期値または外部から制御される値。オプショナル。
- * @property {boolean} [isDasabled] - プロジェクトを固定値にするか判定する値。
+ * @property {boolean} [isDisabled] - プロジェクトを固定値にするか判定する値。
  */
 interface ProjectDropdownComponentProps {
   onChange: (value: string) => void;
   value?: string | null;
-  isDasabled?: boolean;
+  isDisabled?: boolean;
 }
 
 const logger = getLogger('ProjectDropdownComponent');
@@ -42,7 +42,7 @@ const logger = getLogger('ProjectDropdownComponent');
 export const ProjectDropdownComponent = ({
   onChange,
   value,
-  isDasabled,
+  isDisabled,
 }: ProjectDropdownComponentProps): JSX.Element => {
   const { projectMap, isLoading, refresh } = useProjectMap();
   const [selectedValue, setSelectedValue] = useState<string | undefined | null>(value || '');
@@ -96,7 +96,7 @@ export const ProjectDropdownComponent = ({
         onChange={handleChange}
         variant="outlined"
         fullWidth
-        disabled={isDasabled}
+        disabled={isDisabled}
         SelectProps={{
           MenuProps: {
             PaperProps: {

--- a/src/renderer/src/components/task/TaskEdit.tsx
+++ b/src/renderer/src/components/task/TaskEdit.tsx
@@ -86,14 +86,15 @@ export const TaskEdit = ({
       }
       reset(task ? task : {});
       setTask(task);
-      setSelectedProject(task?.projectId || null);
+      if (projectId) {
+        setSelectedProject(projectId);
+        setDasabled(true);
+      } else {
+        setSelectedProject(task?.projectId || null);
+      }
     };
     fetchData();
     setDialogOpen(isOpen);
-    if (projectId) {
-      setSelectedProject(projectId);
-      setDasabled(true); 
-    }
   }, [isOpen, taskId, projectId, reset]);
 
   /**

--- a/src/renderer/src/components/task/TaskEdit.tsx
+++ b/src/renderer/src/components/task/TaskEdit.tsx
@@ -86,11 +86,14 @@ export const TaskEdit = ({
       }
       reset(task ? task : {});
       setTask(task);
+      setSelectedProject(task?.projectId || null);
     };
     fetchData();
     setDialogOpen(isOpen);
-    setSelectedProject(projectId || '');
-    setDasabled(projectId ? true : false);
+    if (projectId) {
+      setSelectedProject(projectId);
+      setDasabled(true); 
+    }
   }, [isOpen, taskId, projectId, reset]);
 
   /**

--- a/src/renderer/src/components/task/TaskEdit.tsx
+++ b/src/renderer/src/components/task/TaskEdit.tsx
@@ -63,7 +63,6 @@ export const TaskEdit = ({
 }: TaskEditProps): JSX.Element => {
   logger.info('TaskEdit', isOpen);
   const [isDasabled, setDasabled] = useState<boolean>(false);
-  const [selectedProject, setSelectedProject] = useState<string | null>(null);
   const [isDialogOpen, setDialogOpen] = useState(isOpen);
   const [task, setTask] = useState<Task | null>(null);
 
@@ -84,14 +83,15 @@ export const TaskEdit = ({
       if (taskId !== null) {
         task = await taskProxy.get(taskId);
       }
-      reset(task ? task : {});
-      setTask(task);
+      let project = '';
       if (projectId) {
-        setSelectedProject(projectId);
+        project = projectId;
         setDasabled(true);
       } else {
-        setSelectedProject(task?.projectId || null);
+        project = task?.projectId || '';
       }
+      reset(task ? task : { projectId: project });
+      setTask(task);
     };
     fetchData();
     setDialogOpen(isOpen);
@@ -190,10 +190,10 @@ export const TaskEdit = ({
             name="projectId"
             control={control}
             rules={{ required: isDasabled ? false : '入力してください。' }}
-            render={({ field: { onChange }, fieldState: { error } }): JSX.Element => (
+            render={({ field: { onChange, value }, fieldState: { error } }): JSX.Element => (
               <FormControl fullWidth>
                 <ProjectDropdownComponent
-                  value={selectedProject}
+                  value={value}
                   onChange={onChange}
                   isDasabled={isDasabled}
                 />

--- a/src/renderer/src/components/task/TaskEdit.tsx
+++ b/src/renderer/src/components/task/TaskEdit.tsx
@@ -87,8 +87,6 @@ export const TaskEdit = ({
       if (projectId) {
         project = projectId;
         setDasabled(true);
-      } else {
-        project = task?.projectId || '';
       }
       reset(task ? task : { projectId: project });
       setTask(task);

--- a/src/renderer/src/components/task/TaskEdit.tsx
+++ b/src/renderer/src/components/task/TaskEdit.tsx
@@ -62,7 +62,7 @@ export const TaskEdit = ({
   onSubmit,
 }: TaskEditProps): JSX.Element => {
   logger.info('TaskEdit', isOpen);
-  const [isDasabled, setDasabled] = useState<boolean>(false);
+  const isProjectDasabled: boolean = projectId ? true : false;
   const [isDialogOpen, setDialogOpen] = useState(isOpen);
   const [task, setTask] = useState<Task | null>(null);
 
@@ -86,7 +86,6 @@ export const TaskEdit = ({
       let project = '';
       if (projectId) {
         project = projectId;
-        setDasabled(true);
       }
       reset(task ? task : { projectId: project });
       setTask(task);
@@ -187,13 +186,13 @@ export const TaskEdit = ({
           <Controller
             name="projectId"
             control={control}
-            rules={{ required: isDasabled ? false : '入力してください。' }}
+            rules={{ required: isProjectDasabled ? false : '入力してください。' }}
             render={({ field: { onChange, value }, fieldState: { error } }): JSX.Element => (
               <FormControl fullWidth>
                 <ProjectDropdownComponent
                   value={value}
                   onChange={onChange}
-                  isDasabled={isDasabled}
+                  isDasabled={isProjectDasabled}
                 />
                 {error && <FormHelperText error={!!error}>{error.message}</FormHelperText>}
               </FormControl>

--- a/src/renderer/src/components/task/TaskEdit.tsx
+++ b/src/renderer/src/components/task/TaskEdit.tsx
@@ -62,7 +62,7 @@ export const TaskEdit = ({
   onSubmit,
 }: TaskEditProps): JSX.Element => {
   logger.info('TaskEdit', isOpen);
-  const isProjectDasabled: boolean = projectId ? true : false;
+  const isProjectDisabled: boolean = projectId ? true : false;
   const [isDialogOpen, setDialogOpen] = useState(isOpen);
   const [task, setTask] = useState<Task | null>(null);
 
@@ -186,13 +186,13 @@ export const TaskEdit = ({
           <Controller
             name="projectId"
             control={control}
-            rules={{ required: isProjectDasabled ? false : '入力してください。' }}
+            rules={{ required: isProjectDisabled ? false : '入力してください。' }}
             render={({ field: { onChange, value }, fieldState: { error } }): JSX.Element => (
               <FormControl fullWidth>
                 <ProjectDropdownComponent
                   value={value}
                   onChange={onChange}
-                  isDasabled={isProjectDasabled}
+                  isDisabled={isProjectDisabled}
                 />
                 {error && <FormHelperText error={!!error}>{error.message}</FormHelperText>}
               </FormControl>


### PR DESCRIPTION
## チケット

#242 

## 対応内容

* Context
    * タスクの編集時に設定されているはずのプロジェクトが表示されないバグが発生。
    * 編集時に初期値としてドロップダウンに設定されているプロジェクトを表示する必要がある。
* Decision
    * fetchDataにプロジェクトIDを設定する処理を追加
    * projectIdの有無で`projectId`固定値するかの分岐を追加
* Consequences
    * 以前の修正でプロジェクトIDを検索したタスクからではなく、引数から`projectId`を取得するようにしたことが原因でバグが発生した。
    * タスクの検索時に`projectId`を設定し、引数で`projectId`が設定されている場合は固定値として表示するように修正を行った。