### PR TITLE
fix: ポモドーロタイマーの修正

### DIFF
--- a/src/renderer/src/components/pomodoroTimer/PomodoroTimer.tsx
+++ b/src/renderer/src/components/pomodoroTimer/PomodoroTimer.tsx
@@ -1,12 +1,25 @@
 import { Button, Grid, Paper, Typography } from '@mui/material';
 import { TimerState, TimerSession } from '@shared/data/PomodoroTimerDetails';
 import { format } from 'date-fns';
-import { useContext } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import pomodoroTimerContext from '../PomodoroTimerContext';
 
 export const PomodoroTimer = (): JSX.Element => {
-  const { pomodoroTimerDetails, startTimer, pauseTimer, stopTimer } =
+  const { pomodoroTimerDetails, startTimer, pauseTimer, stopTimer, setTimer } =
     useContext(pomodoroTimerContext);
+
+  // 依存配列を空にするために Ref を利用する
+  const setTimerRef = useRef<(() => void) | null>(null);
+  setTimerRef.current = (): void => {
+    if (pomodoroTimerDetails && pomodoroTimerDetails.state == TimerState.STOPPED) {
+      setTimer(pomodoroTimerDetails.session);
+    }
+  };
+  useEffect(() => {
+    if (setTimerRef.current) {
+      setTimerRef.current();
+    }
+  }, []);
 
   if (!pomodoroTimerDetails) {
     return <div>Loading...</div>;

--- a/src/renderer/src/components/settings/PomodoroSetting.tsx
+++ b/src/renderer/src/components/settings/PomodoroSetting.tsx
@@ -86,7 +86,7 @@ export const PomodoroTimerSetting = (): JSX.Element => {
                       defaultValue={userPreference?.workingMinutes}
                       rules={{
                         required: '入力してください。',
-                        min: { value: 0, message: '0以上の値を入力してください。' },
+                        min: { value: 1, message: '1以上の値を入力してください。' },
                       }}
                       render={({ field, fieldState: { error } }): React.ReactElement => (
                         <>
@@ -99,7 +99,7 @@ export const PomodoroTimerSetting = (): JSX.Element => {
                             variant="outlined"
                             InputProps={{
                               inputProps: {
-                                min: 0,
+                                min: 1,
                               },
                             }}
                           />
@@ -112,7 +112,7 @@ export const PomodoroTimerSetting = (): JSX.Element => {
                       defaultValue={userPreference?.breakMinutes}
                       rules={{
                         required: '入力してください。',
-                        min: { value: 0, message: '0以上の値を入力してください。' },
+                        min: { value: 1, message: '1以上の値を入力してください。' },
                       }}
                       render={({ field, fieldState: { error } }): React.ReactElement => (
                         <>
@@ -125,7 +125,7 @@ export const PomodoroTimerSetting = (): JSX.Element => {
                             variant="outlined"
                             InputProps={{
                               inputProps: {
-                                min: 0,
+                                min: 1,
                               },
                             }}
                           />


### PR DESCRIPTION
## チケット
#247 
#251 

## 実装内容
- ポモドーロタイマーの画面を開いたとき、タイマーが停止状態なら作業時間・休憩時間を現在の設定に合わせて更新する
- ポモドーロタイマーの設定で作業時間・休憩時間のバリデーションを1分以上にする
- セッション終了時、セッションの時間の設定が0秒だったら通知を送らない(念のため)