### PR TITLE
fix: Googleカレンダー同期の修正

### DIFF
--- a/src/main/services/CalendarSyncProcessorImpl.ts
+++ b/src/main/services/CalendarSyncProcessorImpl.ts
@@ -36,6 +36,7 @@ const logger = getLogger('CalendarSyncProcessorImpl');
  *
  * - EVENT_TYPE.SHARED（共有カレンダー）
  *    - minr 側から新規のイベントが共有カレンダーに同期されることはない。
+ *    - 共有カレンダーから取り込まれたイベントは、minr上で編集・削除して同期できる。
  *    - 常に取り込みが行われたあとの同期処理となる。
  *    - minr の UI 上は、予定のレーンに表示される。
  * - EVENT_TYPE.PLAN（予定カレンダー）
@@ -43,7 +44,14 @@ const logger = getLogger('CalendarSyncProcessorImpl');
  *    - minr の UI 上は、予定のレーンに表示される。
  *    - minr の UI の予定のレーンから登録されたイベントは、予定カレンダーに同期される。
  * - EVENT_TYPE.ACTUAL（実績カレンダー）
- *    - minrの実績は、実績カレンダーと同期する。
+ *    - minr の実績のイベントと同期する
+ *    - minr の UI 上は、実績のレーンに表示される。
+ *    - minr の UI の実績のレーンから登録されたイベントは、実績カレンダーに同期される。
+ *
+ * ■同期対象
+ * minr側で登録されたイベントで、一度も同期されることなく削除されたものは同期しない。
+ * 予定・実績の自動登録で登録された仮状態の予定・実績は同期しない。
+ * 予定・実績の本登録をして、仮状態でなくなった時に同期対象となる。
  *
  * ■同期範囲
  * 同期する範囲は、現在日から -3 日～ 2 週間先までを範囲として、minr のイベントと同期する。
@@ -104,7 +112,10 @@ export class CalendarSyncProcessorImpl implements ITaskProcessor {
         start,
         end
       );
-      const minrEvents = minrEventsAll.filter((ev) => ev.eventType === calendar.eventType);
+      const minrEvents = minrEventsAll
+        .filter((ev) => !ev.deleted)
+        .filter((ev) => !ev.isProvisional)
+        .filter((ev) => ev.eventType === calendar.eventType);
       updateCount += await this.processEventSynchronization(calendar, minrEvents, externalEvents);
     }
     if (updateCount > 0) {
@@ -210,9 +221,9 @@ export class CalendarSyncProcessorImpl implements ITaskProcessor {
     external: ExternalEventEntry
   ): Promise<void> {
     if (logger.isDebugEnabled()) logger.debug('newMinrEvent', external);
-    const usereId = await this.getUserId();
-    if (logger.isDebugEnabled()) logger.debug('usereId', usereId);
-    const data = EventEntryFactory.createFromExternal(usereId, calendarSetting.eventType, external);
+    const userId = await this.getUserId();
+    if (logger.isDebugEnabled()) logger.debug('userId', userId);
+    const data = EventEntryFactory.createFromExternal(userId, calendarSetting.eventType, external);
     await this.eventEntryService.save(data);
   }
 

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -388,7 +388,7 @@ const TimeTable = (): JSX.Element => {
                 onUpdateEventEntry={(eventEntry: EventEntry): void => {
                   // TODO EventDateTime の対応
                   const hour = eventDateTimeToDate(eventEntry.start).getHours();
-                  handleOpenEventEntryForm(FORM_MODE.EDIT, EVENT_TYPE.PLAN, hour, eventEntry);
+                  handleOpenEventEntryForm(FORM_MODE.EDIT, eventEntry.eventType, hour, eventEntry);
                 }}
                 onDragStop={handleDragStop}
                 onResizeStop={handleResizeStop}
@@ -408,7 +408,7 @@ const TimeTable = (): JSX.Element => {
                 onUpdateEventEntry={(eventEntry: EventEntry): void => {
                   // TODO EventDateTime の対応
                   const hour = eventDateTimeToDate(eventEntry.start).getHours();
-                  handleOpenEventEntryForm(FORM_MODE.EDIT, EVENT_TYPE.ACTUAL, hour, eventEntry);
+                  handleOpenEventEntryForm(FORM_MODE.EDIT, eventEntry.eventType, hour, eventEntry);
                 }}
                 onDragStop={handleDragStop}
                 onResizeStop={handleResizeStop}


### PR DESCRIPTION
## チケット
#253 #254 

## 実装内容
- Googleカレンダーで作成→同期→MINRで編集→同期 の手順で変更内容が同期されるように修正
- Googleカレンダーとの同期対象から削除済みのイベントを除外する
- Googleカレンダーとの同期対象から仮状態のイベントを除外する
- ドキュメントの更新