### PR TITLE
fix: 予定の読み上げ関連の修正

### DIFF
--- a/src/main/services/EventNotifyProcessorImpl.ts
+++ b/src/main/services/EventNotifyProcessorImpl.ts
@@ -66,9 +66,10 @@ export class EventNotifyProcessorImpl implements ITaskProcessor {
       now,
       oneHourLater
     );
-    const minrEvents = minrEventsAll.filter(
-      (ev) => ev.eventType === EVENT_TYPE.PLAN || ev.eventType === EVENT_TYPE.SHARED
-    );
+    const minrEvents = minrEventsAll
+      .filter((ev) => !ev.deleted)
+      .filter((ev) => !ev.isProvisional)
+      .filter((ev) => ev.eventType === EVENT_TYPE.PLAN || ev.eventType === EVENT_TYPE.SHARED);
 
     const userPreference = await this.userPreferenceStoreService.getOrCreate(
       await this.getUserId()

--- a/src/renderer/src/components/timeTable/EventEntryForm.tsx
+++ b/src/renderer/src/components/timeTable/EventEntryForm.tsx
@@ -495,16 +495,18 @@ const EventEntryForm = ({
                       )}
                     />
                   </Grid>
-                  {(eventType === EVENT_TYPE.PLAN || eventType === EVENT_TYPE.SHARED) && (
-                    <Grid item xs={12}>
-                      <FormLabel component="legend">リマインダーの設定</FormLabel>
-                      <NotificationSettingsFormControl
-                        name={`notificationSetting`}
-                        control={control}
-                        notificationTimeOffsetProps={{ label: '通知タイミング(秒前)' }}
-                      />
-                    </Grid>
-                  )}
+                  {/* 仮予定以外の予定でリマインダーの設定を表示 */}
+                  {(eventType === EVENT_TYPE.PLAN || eventType === EVENT_TYPE.SHARED) &&
+                    (!eventEntry || !eventEntry.isProvisional) && (
+                      <Grid item xs={12}>
+                        <FormLabel component="legend">リマインダーの設定</FormLabel>
+                        <NotificationSettingsFormControl
+                          name={`notificationSetting`}
+                          control={control}
+                          notificationTimeOffsetProps={{ label: '通知タイミング(秒前)' }}
+                        />
+                      </Grid>
+                    )}
                 </Grid>
               </Paper>
             </Grid>


### PR DESCRIPTION
## チケット
#257 

## 実装内容
- 削除された予定を音声読み上げ・デスクトップ通知の対象から除外する
- 仮予定を音声読み上げ・デスクトップ通知の対象から除外する
- 仮予定にリマインダーの設定を表示しない