### PR TITLE
fix: ヘルプのダイアログにテーマが適用されない

### DIFF
--- a/src/renderer/src/components/DrawerAppBar.tsx
+++ b/src/renderer/src/components/DrawerAppBar.tsx
@@ -140,7 +140,7 @@ const DrawerAppBar = (props: Props): JSX.Element => {
             <Button onClick={openHelp} sx={{ color: textColor }}>
               {menu.MENU_HELP.name}
             </Button>
-            {helpOpen && <Help onClose={closeHelp} />}
+            {helpOpen && <Help onClose={closeHelp} theme={theme} />}
           </Box>
         </Toolbar>
       </AppBar>

--- a/src/renderer/src/components/DrawerAppBar.tsx
+++ b/src/renderer/src/components/DrawerAppBar.tsx
@@ -140,7 +140,7 @@ const DrawerAppBar = (props: Props): JSX.Element => {
             <Button onClick={openHelp} sx={{ color: textColor }}>
               {menu.MENU_HELP.name}
             </Button>
-            {helpOpen && <Help onClose={closeHelp} theme={theme} />}
+            {helpOpen && <Help onClose={closeHelp} />}
           </Box>
         </Toolbar>
       </AppBar>

--- a/src/renderer/src/components/help/Help.tsx
+++ b/src/renderer/src/components/help/Help.tsx
@@ -1,8 +1,7 @@
-import { Button, Box, Theme } from '@mui/material';
+import { Button, Box, useTheme } from '@mui/material';
 import ReactDOM from 'react-dom';
 interface ModalProps {
   onClose: () => void;
-  theme: Theme;
 }
 
 // アプリのバージョン番号
@@ -20,7 +19,8 @@ const version = '0.1.4';
  * @param onClose モーダルを閉じる用メソッド
  * @returns {React.ReactPortal} レンダリング結果。
  */
-const Help: React.FC<ModalProps> = ({ onClose, theme }) => {
+const Help: React.FC<ModalProps> = ({ onClose }) => {
+  const theme = useTheme();
   const bodyBackground =
     theme.palette.mode === 'dark' ? theme.palette.grey[900] : theme.palette.grey[50];
   const textColor =

--- a/src/renderer/src/components/help/Help.tsx
+++ b/src/renderer/src/components/help/Help.tsx
@@ -1,11 +1,12 @@
-import { Button, Box } from '@mui/material';
+import { Button, Box, Theme } from '@mui/material';
 import ReactDOM from 'react-dom';
 interface ModalProps {
   onClose: () => void;
+  theme: Theme;
 }
 
 // アプリのバージョン番号
-const version = '0.1.2';
+const version = '0.1.4';
 
 /**
  * ヘルプ画面コンポーネント
@@ -19,7 +20,12 @@ const version = '0.1.2';
  * @param onClose モーダルを閉じる用メソッド
  * @returns {React.ReactPortal} レンダリング結果。
  */
-const Help: React.FC<ModalProps> = ({ onClose }) => {
+const Help: React.FC<ModalProps> = ({ onClose, theme }) => {
+  const bodyBackground =
+    theme.palette.mode === 'dark' ? theme.palette.grey[900] : theme.palette.grey[50];
+  const textColor =
+    theme.palette.mode === 'dark' ? theme.palette.grey[50] : theme.palette.grey[900];
+
   return ReactDOM.createPortal(
     <>
       <Box
@@ -40,8 +46,8 @@ const Help: React.FC<ModalProps> = ({ onClose }) => {
             zIndex: 2,
             width: '25%',
             padding: '1em',
-            background: '#fff',
-            color: 'rgba(0,0,0,255)',
+            background: bodyBackground,
+            color: textColor,
             fontSize: '24px',
           }}
         >

--- a/src/renderer/src/components/help/Help.tsx
+++ b/src/renderer/src/components/help/Help.tsx
@@ -61,6 +61,7 @@ const Help: React.FC<ModalProps> = ({ onClose }) => {
               href="https://github.com/minr-dev/desktop/releases"
               target="_blank"
               rel="noopener noreferrer"
+              style={{ color: theme.palette.primary.main }}
             >
               最新版のダウンロードはこちらから
             </a>


### PR DESCRIPTION
## チケット

#260 

## 対応内容

* Context
    * 設定からテーマが変更されたときに、ヘルプのダイアログも同じくテーマに合わせて変更される。
* Decision
    * テーマの引数を追加し、ヘルプ内でテーマを色を適用するように修正を行った。
* Consequences
    * App.tsxでは`Theme`を使用しているが、あらかじめ変数で宣言されている色データを適用している。
    * ヘルプは`App`や`DrawAppBar`の`Theme`の適用外なので、他のテーマと色を合わせるために同様の変数をヘルプ内で宣言し使用する。

## 追加対応

* バージョンが`0.1.4`に変更されたので適用する。