### PR TITLE
fix: 設定(タスク)での更新が予実フォームのタスクドロップダウンに反映されない

### DIFF
--- a/src/renderer/src/components/task/TaskDropdownComponent.tsx
+++ b/src/renderer/src/components/task/TaskDropdownComponent.tsx
@@ -50,23 +50,28 @@ export const TaskDropdownComponent = ({
   const { refresh: taskRefresh } = useTaskMap();
   const [isDialogOpen, setDialogOpen] = useState(false);
 
+  useEffect(() => {
+    setSelectedValue(value || '');
+  }, [value]);
+
   // プロジェクトが変更されると、選択中のタスクは不整合になるので、値をリセットする
   // ただ、フォーム初期化時にプロジェクトとタスクが同時に更新されるため、
   // そこで値がリセットされるとタスクの初期値が反映されない。
   // そのため、もともと projectId が入っていた時だけ変更されるようにする。
   const previousProjectId = useRef<string>('');
   useEffect(() => {
+    if (previousProjectId.current) {
+      setSelectedValue('');
+    }
+    previousProjectId.current = projectId;
+  }, [projectId]);
+
+  useEffect(() => {
     const refetch = async (): Promise<void> => {
       await filteredTaskRefresh();
     };
-    if (previousProjectId.current) {
-      setSelectedValue('');
-    } else {
-      setSelectedValue(value || '');
-    }
-    previousProjectId.current = projectId;
     refetch();
-  }, [value, projectId, filteredTaskRefresh]);
+  }, [filteredTaskRefresh]);
 
   /**
    * タスク変更ハンドラー

--- a/src/renderer/src/components/task/TaskDropdownComponent.tsx
+++ b/src/renderer/src/components/task/TaskDropdownComponent.tsx
@@ -50,21 +50,23 @@ export const TaskDropdownComponent = ({
   const { refresh: taskRefresh } = useTaskMap();
   const [isDialogOpen, setDialogOpen] = useState(false);
 
-  useEffect(() => {
-    setSelectedValue(value || '');
-  }, [value]);
-
   // プロジェクトが変更されると、選択中のタスクは不整合になるので、値をリセットする
   // ただ、フォーム初期化時にプロジェクトとタスクが同時に更新されるため、
   // そこで値がリセットされるとタスクの初期値が反映されない。
   // そのため、もともと projectId が入っていた時だけ変更されるようにする。
   const previousProjectId = useRef<string>('');
   useEffect(() => {
+    const refetch = async (): Promise<void> => {
+      await filteredTaskRefresh();
+    };
     if (previousProjectId.current) {
       setSelectedValue('');
+    } else {
+      setSelectedValue(value || '');
     }
     previousProjectId.current = projectId;
-  }, [projectId]);
+    refetch();
+  }, [value, projectId, filteredTaskRefresh]);
 
   /**
    * タスク変更ハンドラー


### PR DESCRIPTION
## チケット

#263 

## 対応内容

* Context
    * 設定からタスクを追加時にタイムラインには即時反映されている必要がある。
* Decision
    * タスクドロップダウンのuseEffectに更新処理を追加
* Consequences
    * ドロップダウンからタスクを追加時は即時反映されていた
    * タイムラインを開いた際に更新処理が行われていないので、ドロップダウンを開いた時に更新されるように修正を行う。

## 追加対応

* `TaskDropdownComponent`の2つのuseEffectを1つに統合