### PR TITLE
fix: ドロップダウンにてプロジェクトが無くても新規追加したタスクを登録できてしまう

### DIFF
--- a/src/renderer/src/components/task/TaskDropdownComponent.tsx
+++ b/src/renderer/src/components/task/TaskDropdownComponent.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, MenuItem, TextField } from '@mui/material';
+import { Box, Button, FormHelperText, MenuItem, TextField } from '@mui/material';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import { useTaskMap, useTaskMapFilteredByProject } from '@renderer/hooks/useTaskMap';
 import { Task } from '@shared/data/Task';
@@ -103,13 +103,8 @@ export const TaskDropdownComponent = ({
     if (logger.isDebugEnabled()) logger.debug('handleDialogSubmit', task);
     await taskRefresh();
     await filteredTaskRefresh();
-    if (projectId !== '') {
-      setSelectedValue(task.id);
-      onChange(task.id);
-    } else {
-      setSelectedValue('');
-      onChange('');
-    }
+    setSelectedValue(task.id);
+    onChange(task.id);
   };
 
   if (isLoading) {
@@ -148,10 +143,17 @@ export const TaskDropdownComponent = ({
           </MenuItem>
         ))}
         <Box borderTop={1}>
-          <Button variant="text" color="primary" onClick={handleAdd}>
-            <AddCircleIcon sx={{ marginRight: '0.5rem' }} />
-            新しいタスクを作成する
-          </Button>
+          {projectId !== '' && (
+            <Button variant="text" color="primary" onClick={handleAdd}>
+              <AddCircleIcon sx={{ marginRight: '0.5rem' }} />
+              新しいタスクを作成する
+            </Button>
+          )}
+          {projectId === '' && (
+            <FormHelperText sx={{ marginLeft: '1rem', alignSelf: 'center' }}>
+              プロジェクトを選択してください
+            </FormHelperText>
+          )}
         </Box>
       </TextField>
       {isDialogOpen && (

--- a/src/renderer/src/components/task/TaskDropdownComponent.tsx
+++ b/src/renderer/src/components/task/TaskDropdownComponent.tsx
@@ -103,8 +103,13 @@ export const TaskDropdownComponent = ({
     if (logger.isDebugEnabled()) logger.debug('handleDialogSubmit', task);
     await taskRefresh();
     await filteredTaskRefresh();
-    setSelectedValue(task.id);
-    onChange(task.id);
+    if (projectId !== '') {
+      setSelectedValue(task.id);
+      onChange(task.id);
+    } else {
+      setSelectedValue('');
+      onChange('');
+    }
   };
 
   if (isLoading) {


### PR DESCRIPTION
## チケット

#266 

## 対応内容

* Context
    * ドロップダウンからタスクを追加した際に追加したタスクを選択する。
    * タスクはプロジェクトと紐づいて登録されている必要がある。
    * ドロップダウンからタスクを追加した際にプロジェクトが空の場合は何も選択されていない必要がある。
* Decision
    * ~~プロジェクト未選択でタスクを登録した際は空文字を選択した状態にするように修正~~
    * プロジェクトが未選択時は「プロジェクトを選択してください」とヘルプを表示するように修正
* Consequences
    * ドロップダウンからタスクを追加した際に追加したタスクを選択する仕様になっていた。
    * ~~プロジェクトが選択されていないときはタスクの選択も同様に何も選択されていない状態を返すように修正する。~~
    * プロジェクトが未選択場合は紐づくプロジェクトが無いため、タスクは追加できない方がわかりやすい。