### PR TITLE
fix: イベント・パターンのラベル選択で新規ラベルを作成すると、空のラベルが登録される

### DIFF
--- a/src/renderer/src/components/label/LabelMultiSelectComponent.tsx
+++ b/src/renderer/src/components/label/LabelMultiSelectComponent.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { MenuItem, Box, Button } from '@mui/material';
+import { MenuItem, Box, Button, Paper } from '@mui/material';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import { Label } from '@shared/data/Label';
 import { useTheme } from '@mui/material/styles';
@@ -91,6 +91,16 @@ export const LabelMultiSelectComponent = ({
     return a.name.localeCompare(b.name);
   });
 
+  const paperWithButton = ({ children, button, ...other }, ref): JSX.Element => {
+    return (
+      <Paper ref={ref} {...other}>
+        {children}
+        <Box borderTop={1}>{button}</Box>
+      </Paper>
+    );
+  };
+  const paperWithButtonRef = React.forwardRef(paperWithButton);
+
   return (
     <>
       <FormControl fullWidth>
@@ -107,13 +117,35 @@ export const LabelMultiSelectComponent = ({
           input={<OutlinedInput id={`${field.id}-select-multiple`} label="ラベル" />}
           renderValue={(selected): React.ReactNode => (
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-              {selected.map((id: Label['id']) => (
-                <Chip key={id} label={labelMap.get(id)?.name || ''} />
-              ))}
+              {selected.map((id: Label['id']) => {
+                const label = labelMap.get(id);
+                return label ? <Chip key={id} label={label.name} /> : <></>;
+              })}
             </Box>
           )}
           MenuProps={{
+            /**
+             * 追加ボタンを押したときに空のラベルが選択される不具合の対応
+             *
+             * 現状のMUIの機能では簡潔にこの問題を解決することができない
+             * https://github.com/mui/material-ui/issues/26356
+             * ひとまずはここに書かれている回避策で対応する
+             *
+             * TODO: MUI側でこの問題が解決されたときに、このコードも修正する
+             */
             PaperProps: {
+              component: paperWithButtonRef,
+              button: (
+                <Button
+                  variant="text"
+                  color="primary"
+                  onClick={handleAdd}
+                  sx={{ marginBottom: '10px' }}
+                >
+                  <AddCircleIcon sx={{ marginRight: '0.5rem' }} />
+                  新しいラベルを作成する
+                </Button>
+              ),
               style: {
                 maxHeight: '20rem',
               },
@@ -134,12 +166,6 @@ export const LabelMultiSelectComponent = ({
               {label.name}
             </MenuItem>
           ))}
-          <Box borderTop={1}>
-            <Button variant="text" color="primary" onClick={handleAdd}>
-              <AddCircleIcon sx={{ marginRight: '0.5rem' }} />
-              新しいラベルを作成する
-            </Button>
-          </Box>
         </Select>
       </FormControl>
       {isDialogOpen && (


### PR DESCRIPTION
## チケット
#265 

## 実装内容
- ラベル選択で新規ラベル追加時に空のラベルが登録される不具合の修正
  - `Select`の仕様で、`MenuItem`以外のコンポーネントを押したときに`undefined`を選択した扱いになる
  - MUIのGitHubでもIssueが作られており、進行中
    - https://github.com/mui/material-ui/issues/26356
  - 今回は、上記Issue内で示されていた現状できる対応のサンプルコードをもとに修正した
    - https://codesandbox.io/p/sandbox/select-multi-with-close-button-j8to8
  - かなり煩雑な実装なので、MUI側で機能改善されたらそれに合わせて修正したい
- `id`から見つからなかったラベルはラベル選択で`Chip`を表示しない
  - イベントにラベル登録→設定(ラベル)でラベル削除、としたときに、イベントに消せない`Chip`が残ってしまうため