### PR TITLE
feat: #56 OS起動時にアプリを自動起動する設定

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minr-desktop",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",
@@ -11515,10 +11515,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "node_modules/minr-desktop": {
-      "resolved": "",
-      "link": true
-    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -11905,6 +11901,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/openid-client/node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.4",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
-  "author": "msato@altus5.com",
+  "author": "Altus-five Inc.",
   "homepage": "https://github.com/minr-dev/desktop",
   "scripts": {
     "dotenv": "shx cp .env.example .env",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.4-issue-56",
+  "version": "0.1.4",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "Altus-five Inc.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.4",
+  "version": "0.1.4-issue-56",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "Altus-five Inc.",

--- a/src/main/inversify.main.config.ts
+++ b/src/main/inversify.main.config.ts
@@ -92,6 +92,9 @@ import { EventAggregationServiceImpl } from './services/EventAggregationServiceI
 import { PlanAutoRegistrationServiceHandlerImpl } from './ipc/PlanAutoRegistrationServiceHandlerImpl';
 import { ITaskProviderService } from './services/ITaskProviderService';
 import { TaskProviderServiceImpl } from './services/TaskProviderServiceImpl';
+import { IAutoLaunchService } from './services/IAutoLaunchService';
+import { AutoLaunchServiceImpl } from './services/AutoLaunchServiceImpl';
+import { AutoLaunchServiceHandlerImpl } from './ipc/AutoLaunchServiceHandlerImpl';
 
 // コンテナの作成
 const container = new Container();
@@ -148,6 +151,10 @@ container
 container
   .bind<IIpcHandlerInitializer>(TYPES.IpcHandlerInitializer)
   .to(GitHubEventStoreHandlerImpl)
+  .inSingletonScope();
+container
+  .bind<IIpcHandlerInitializer>(TYPES.IpcHandlerInitializer)
+  .to(AutoLaunchServiceHandlerImpl)
   .inSingletonScope();
 container
   .bind<IIpcHandlerInitializer>(TYPES.IpcHandlerInitializer)
@@ -266,6 +273,10 @@ container
 container
   .bind<IEventAggregationService>(TYPES.EventAggregationService)
   .to(EventAggregationServiceImpl)
+  .inSingletonScope();
+container
+  .bind<IAutoLaunchService>(TYPES.AutoLaunchService)
+  .to(AutoLaunchServiceImpl)
   .inSingletonScope();
 
 // TaskScheduler と ITaskProcessor のバインド

--- a/src/main/ipc/AutoLaunchServiceHandlerImpl.ts
+++ b/src/main/ipc/AutoLaunchServiceHandlerImpl.ts
@@ -1,0 +1,24 @@
+import { IpcChannel } from '@shared/constants';
+import { ipcMain } from 'electron';
+import { inject, injectable } from 'inversify';
+import type { IIpcHandlerInitializer } from './IIpcHandlerInitializer';
+import { TYPES } from '@main/types';
+import type { IAutoLaunchService } from '@main/services/IAutoLaunchService';
+
+/**
+ * 自動起動の切り替えを行う IPC ハンドラー
+ */
+@injectable()
+export class AutoLaunchServiceHandlerImpl implements IIpcHandlerInitializer {
+  constructor(
+    @inject(TYPES.AutoLaunchService)
+    private readonly autoLaunchService: IAutoLaunchService
+  ) {}
+
+  init(): void {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    ipcMain.handle(IpcChannel.SET_AUTO_LAUNCH_ENABLED, async (_event, isEnabled) => {
+      return await this.autoLaunchService.setAutoLaunchEnabled(isEnabled);
+    });
+  }
+}

--- a/src/main/services/AutoLaunchServiceImpl.ts
+++ b/src/main/services/AutoLaunchServiceImpl.ts
@@ -1,0 +1,25 @@
+import { app } from 'electron';
+import { IAutoLaunchService } from './IAutoLaunchService';
+import { injectable } from 'inversify';
+import { is } from '@electron-toolkit/utils';
+import { getLogger } from '@main/utils/LoggerUtil';
+
+const logger = getLogger('AutoLaunchService');
+
+@injectable()
+export class AutoLaunchServiceImpl implements IAutoLaunchService {
+  async setAutoLaunchEnabled(isEnabled: boolean): Promise<void> {
+    logger.debug('setAutoLaunchEnabled', isEnabled);
+    if (!app.isReady()) {
+      await app.whenReady();
+    }
+    if (is.dev || !app.isPackaged) {
+      logger.warn('Auto-launch setting is disabled in development.');
+      return;
+    }
+    const setting = app.getLoginItemSettings();
+    if (setting.openAtLogin != isEnabled) {
+      app.setLoginItemSettings({ ...setting, openAtLogin: isEnabled });
+    }
+  }
+}

--- a/src/main/services/IAutoLaunchService.ts
+++ b/src/main/services/IAutoLaunchService.ts
@@ -1,0 +1,3 @@
+export interface IAutoLaunchService {
+  setAutoLaunchEnabled(isEnabled: boolean): Promise<void>;
+}

--- a/src/main/services/UserPreferenceStoreServiceImpl.ts
+++ b/src/main/services/UserPreferenceStoreServiceImpl.ts
@@ -25,6 +25,8 @@ export class UserPreferenceStoreServiceImpl implements IUserPreferenceStoreServi
   }
 
   private defaultUserPreference: Omit<UserPreference, 'userId' | 'updated'> = {
+    openAtLogin: false,
+
     syncGoogleCalendar: false,
     calendars: [],
 

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -35,6 +35,7 @@ export const TYPES = {
   TaskProviderService: Symbol.for('TaskProviderService'),
   TaskAllocationService: Symbol.for('TaskAllocationService'),
   EventAggregationService: Symbol.for('EventAggrgationService'),
+  AutoLaunchService: Symbol.for('AutoLaunchService'),
 
   TaskScheduler: Symbol.for('TaskScheduler'),
   CalendarSyncProcessor: Symbol.for('CalendarSyncProcessor'),

--- a/src/renderer/src/components/settings/GeneralSetting.tsx
+++ b/src/renderer/src/components/settings/GeneralSetting.tsx
@@ -29,6 +29,7 @@ import { TimePickerField } from '../common/fields/TimePickerField';
 import { AppError } from '@shared/errors/AppError';
 import { useAppSnackbar } from '@renderer/hooks/useAppSnackbar';
 import { getLogger } from '@renderer/utils/LoggerUtil';
+import { IAutoLaunchProxy } from '@renderer/services/IAutoLaunchProxy';
 
 const logger = getLogger('GeneralSetting');
 
@@ -86,6 +87,7 @@ export const GeneralSetting = (): JSX.Element => {
         TYPES.UserPreferenceProxy
       );
       const userPreference = await userPreferenceProxy.getOrCreate(userDetails.userId);
+      const autoLaunchProxy = rendererContainer.get<IAutoLaunchProxy>(TYPES.AutoLaunchProxy);
       const updateData = { ...userPreference, ...data };
       updateData.startHourLocal = Number(updateData.startHourLocal);
       updateData.dailyWorkHours = Number(updateData.dailyWorkHours);
@@ -94,9 +96,11 @@ export const GeneralSetting = (): JSX.Element => {
       updateData.speakTimeSignal = Boolean(updateData.speakTimeSignal);
       updateData.timeSignalInterval = Number(updateData.timeSignalInterval);
       updateData.muteWhileInMeeting = Boolean(updateData.muteWhileInMeeting);
+      updateData.openAtLogin = Boolean(updateData.openAtLogin);
       await userPreferenceProxy.save(updateData);
       setThemeMode(updateData.theme as PaletteMode);
-
+      if (logger.isDebugEnabled()) logger.debug('自動起動更新');
+      autoLaunchProxy.setAutoLaunchEnabled(updateData.openAtLogin);
       enqueueAppSnackbar('保存しました。', { variant: 'info' });
     }
   };
@@ -320,6 +324,26 @@ export const GeneralSetting = (): JSX.Element => {
                     <AddCircleIcon />
                     追加
                   </Button>
+                </Grid>
+              </Paper>
+            </Grid>
+            <Grid item xs={12}>
+              <Paper variant="outlined">
+                <Grid container spacing={2} padding={2}>
+                  <Grid item xs={12}>
+                    <Controller
+                      name={`openAtLogin`}
+                      control={control}
+                      defaultValue={false}
+                      rules={{ required: false }}
+                      render={({ field }): React.ReactElement => (
+                        <FormControlLabel
+                          control={<Checkbox {...field} checked={field.value} />}
+                          label={`自動起動する`}
+                        />
+                      )}
+                    />
+                  </Grid>
                 </Grid>
               </Paper>
             </Grid>

--- a/src/renderer/src/inversify.renderer.config.ts
+++ b/src/renderer/src/inversify.renderer.config.ts
@@ -43,6 +43,8 @@ import { IActualAutoRegistrationProxy } from './services/IActualAutoRegistration
 import { ActualAutoRegistrationProxy } from './services/ActualAutoRegistrationProxy';
 import { IPlanAutoRegistrationProxy } from './services/IPlanAutoRegistrationProxy';
 import { PlanAutoRegistrationProxy } from './services/PlanAutoRegistrationProxy';
+import { IAutoLaunchProxy } from './services/IAutoLaunchProxy';
+import { AutoLaunchProxyImpl } from './services/AutoLaunchProxyImpl';
 
 // コンテナの作成
 const container = new Container();
@@ -83,6 +85,7 @@ container
   .bind<IPlanAutoRegistrationProxy>(TYPES.PlanAutoRegistrationProxy)
   .to(PlanAutoRegistrationProxy)
   .inSingletonScope();
+container.bind<IAutoLaunchProxy>(TYPES.AutoLaunchProxy).to(AutoLaunchProxyImpl).inSingletonScope();
 container.bind<ICategoryProxy>(TYPES.CategoryProxy).to(CategoryProxyImpl).inSingletonScope();
 container.bind<ILabelProxy>(TYPES.LabelProxy).to(LabelProxyImpl).inSingletonScope();
 container.bind<IProjectProxy>(TYPES.ProjectProxy).to(ProjectProxyImpl).inSingletonScope();

--- a/src/renderer/src/services/AutoLaunchProxyImpl.ts
+++ b/src/renderer/src/services/AutoLaunchProxyImpl.ts
@@ -1,0 +1,16 @@
+import { IpcChannel } from '@shared/constants';
+import { IAutoLaunchProxy } from './IAutoLaunchProxy';
+import { handleIpcOperation } from './ipcErrorHandling';
+import { injectable } from 'inversify';
+
+@injectable()
+export class AutoLaunchProxyImpl implements IAutoLaunchProxy {
+  async setAutoLaunchEnabled(isEnabled: boolean): Promise<void> {
+    return await handleIpcOperation(async () => {
+      return await window.electron.ipcRenderer.invoke(
+        IpcChannel.SET_AUTO_LAUNCH_ENABLED,
+        isEnabled
+      );
+    });
+  }
+}

--- a/src/renderer/src/services/IAutoLaunchProxy.ts
+++ b/src/renderer/src/services/IAutoLaunchProxy.ts
@@ -1,0 +1,3 @@
+export interface IAutoLaunchProxy {
+  setAutoLaunchEnabled(isEnabled: boolean): Promise<void>;
+}

--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -16,6 +16,7 @@ export const TYPES = {
   PlanAutoRegistrationProxy: Symbol.for('PlanAutoRegistrationProxy'),
   CalendarSynchronizerProxy: Symbol.for('CalendarSynchronizerProxy'),
   GitHubSynchronizerProxy: Symbol.for('GitHubSynchronizerProxy'),
+  AutoLaunchProxy: Symbol.for('AutoLaunchProxy'),
   CategoryProxy: Symbol.for('CategoryProxy'),
   LabelProxy: Symbol.for('LabelProxy'),
   ProjectProxy: Symbol.for('ProjectProxy'),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -63,6 +63,8 @@ export enum IpcChannel {
   PATTERN_DELETE = 'pattern_delete',
   PATTERN_BULK_DELETE = 'pattern_bulk_delete',
 
+  SET_AUTO_LAUNCH_ENABLED = 'set_auto_launch_enabled',
+
   CALENDAR_GET = 'calendar_get',
   CALENDAR_SYNC = 'calendar_sync',
 

--- a/src/shared/data/UserPreference.ts
+++ b/src/shared/data/UserPreference.ts
@@ -6,6 +6,8 @@ import { TimeSlot } from './TimeSlot';
 export interface UserPreference {
   userId: string;
 
+  openAtLogin: boolean;
+
   syncGoogleCalendar: boolean;
   calendars: CalendarSetting[];
 

--- a/src/shared/data/__tests__/UserPreferenceFixture.ts
+++ b/src/shared/data/__tests__/UserPreferenceFixture.ts
@@ -6,6 +6,7 @@ export class UserPreferenceFixture {
   static default(override: Partial<UserPreference> = {}): UserPreference {
     return {
       userId: 'user123',
+      openAtLogin: false,
       syncGoogleCalendar: true,
       calendars: [CalendarSettingFixture.default()],
       startHourLocal: 9,


### PR DESCRIPTION
## チケット
#56 
#60 

## 実装内容
- 設定(一般)に自動起動の設定を追加
- 自動起動を設定/解除する処理の追加
  - 開発環境では自動起動の設定はしないようにする(正常に動作しないらしい)
  - ユーザーがWindowsの設定でスタートアップを無効にすると、自動起動するにチェックがついていても起動しない
    - この状態で自動起動をOFFにしても不整合は起きない
- `package.json`の`author`を会社名に変更
  - プロパティの著作権のところが会社名になりました