### PR TITLE
fix: #206 Mac版でリリースができるようにする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,8 +126,6 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-
-          DEBUG: electron-osx-sign*
         run: npm run build:${{ matrix.platform }}
 
       - name: delete Apple API Key File

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,18 +40,17 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2022] # macos-13, macos-14, ubuntu-24.04
+        os: [windows-2022, macos-13, macos-14] # ubuntu-24.04
         node-version: [18.x]
         include:
-          # Mac版は署名がうまくいっていないため保留
-          # - os: macos-13
-          #   platform: mac
-          #   ext: dmg
-          #   arch: x64
-          # - os: macos-14
-          #   platform: mac
-          #   ext: dmg
-          #   arch: arm64
+          - os: macos-13
+            platform: mac
+            ext: dmg
+            arch: x64
+          - os: macos-14
+            platform: mac
+            ext: dmg
+            arch: arm64
           - os: windows-2022
             platform: win
             ext: exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,8 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+          DEBUG: electron-osx-sign*
         run: npm run build:${{ matrix.platform }}
 
       - name: delete Apple API Key File

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -45,5 +45,5 @@ linux:
   category: Utility
 appImage:
   artifactName: ${name}-${version}-linux-${arch}.${ext}
-npmRebuild: false
+npmRebuild: true
 publish: null

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,6 +11,7 @@ files:
   - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
 asarUnpack:
   - resources/**
+  - node_modules/**/*.node
 afterSign: build/notarize.js
 win:
   icon: build/icon.ico

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -46,5 +46,5 @@ linux:
   category: Utility
 appImage:
   artifactName: ${name}-${version}-linux-${arch}.${ext}
-npmRebuild: true
+npmRebuild: false
 publish: null

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.4-issue-206-3",
+  "version": "0.1.4-issue-206-5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minr-desktop",
-      "version": "0.1.4-issue-206-3",
+      "version": "0.1.4-issue-206-5",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.4",
+  "version": "0.1.4-issue-206-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minr-desktop",
-      "version": "0.1.4",
+      "version": "0.1.4-issue-206-3",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.4-issue-206-5",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minr-desktop",
-      "version": "0.1.4-issue-206-5",
+      "version": "0.1.5",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.4-issue-206-2",
+  "version": "0.1.4-issue-206-3",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "Altus-five Inc.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.4",
+  "version": "0.1.4-issue-206-1",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "Altus-five Inc.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.4-issue-206-5",
+  "version": "0.1.5",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "Altus-five Inc.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.4-issue-206-4",
+  "version": "0.1.4-issue-206-5",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "Altus-five Inc.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.4-issue-206-3",
+  "version": "0.1.4-issue-206-4",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "Altus-five Inc.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minr-desktop",
-  "version": "0.1.4-issue-206-1",
+  "version": "0.1.4-issue-206-2",
   "description": "A tool to support the workflow of developers on desktop environments.",
   "main": "./out/main/index.js",
   "author": "Altus-five Inc.",


### PR DESCRIPTION
## チケット
#206 

## 実装内容
- `asarUnpack`に`node_modules`の`.node`ファイルを追加
  - これによりライブラリに署名がされ、署名の問題が解決する