### PR TITLE
feat: 予定の自動登録で、登録タスクのプロジェクトを指定できるようにする(rendererプロセス)

### DIFF
--- a/src/main/ipc/PlanAutoRegistrationServiceHandlerImpl.ts
+++ b/src/main/ipc/PlanAutoRegistrationServiceHandlerImpl.ts
@@ -15,11 +15,12 @@ export class PlanAutoRegistrationServiceHandlerImpl implements IIpcHandlerInitia
   init(): void {
     ipcMain.handle(
       IpcChannel.AUTO_REGISTER_PROVISIONAL_PLANS,
-      async (_event, targetDate, taskExtraHours?) => {
-        return await this.planAutoRegistrationService.autoRegisterProvisional(
-          targetDate,
-          taskExtraHours
-        );
+      async (_event, targetDate, taskExtraHours?, projectId?) => {
+        return await this.planAutoRegistrationService.autoRegisterProvisional({
+          targetDate: targetDate,
+          taskExtraHours: taskExtraHours,
+          projectId: projectId,
+        });
       }
     );
 

--- a/src/main/ipc/PlanAutoRegistrationServiceHandlerImpl.ts
+++ b/src/main/ipc/PlanAutoRegistrationServiceHandlerImpl.ts
@@ -18,8 +18,8 @@ export class PlanAutoRegistrationServiceHandlerImpl implements IIpcHandlerInitia
       async (_event, targetDate, taskExtraHours?, projectId?) => {
         return await this.planAutoRegistrationService.autoRegisterProvisional({
           targetDate: targetDate,
-          taskExtraHours: taskExtraHours,
           projectId: projectId,
+          taskExtraHours: taskExtraHours,
         });
       }
     );

--- a/src/main/services/IPlanAutoRegistrationService.ts
+++ b/src/main/services/IPlanAutoRegistrationService.ts
@@ -2,8 +2,8 @@ import { PlanAutoRegistrationResult } from '@shared/data/PlanAutoRegistrationRes
 
 export interface PlanAutoRegistrationParams {
   targetDate: Date;
-  taskExtraHours?: Map<string, number>;
   projectId?: string;
+  taskExtraHours?: Map<string, number>;
 }
 
 export interface IPlanAutoRegistrationService {

--- a/src/main/services/IPlanAutoRegistrationService.ts
+++ b/src/main/services/IPlanAutoRegistrationService.ts
@@ -1,10 +1,13 @@
 import { PlanAutoRegistrationResult } from '@shared/data/PlanAutoRegistrationResult';
 
+export interface PlanAutoRegistrationParams {
+  targetDate: Date;
+  taskExtraHours?: Map<string, number>;
+  projectId?: string;
+}
+
 export interface IPlanAutoRegistrationService {
-  autoRegisterProvisional(
-    targetDate: Date,
-    taskExtraHours?: Map<string, number>
-  ): Promise<PlanAutoRegistrationResult>;
+  autoRegisterProvisional(params: PlanAutoRegistrationParams): Promise<PlanAutoRegistrationResult>;
   confirmRegistration(targetDate: Date): Promise<void>;
   deleteProvisional(targetDate: Date): Promise<void>;
 }

--- a/src/main/services/ITaskProviderService.ts
+++ b/src/main/services/ITaskProviderService.ts
@@ -1,5 +1,5 @@
 import { Task } from '@shared/data/Task';
 
 export interface ITaskProviderService {
-  getTasksForAllocation(targetDate: Date): Promise<Task[]>;
+  getTasksForAllocation(targetDate: Date, projectId?: string): Promise<Task[]>;
 }

--- a/src/main/services/TaskProviderServiceImpl.ts
+++ b/src/main/services/TaskProviderServiceImpl.ts
@@ -26,8 +26,8 @@ export class TaskProviderServiceImpl implements ITaskProviderService {
     @inject(TYPES.TaskService)
     private readonly taskService: ITaskService
   ) {}
-  // TODO: 単体テストの実装
-  async getTasksForAllocation(targetDate: Date): Promise<Task[]> {
+
+  async getTasksForAllocation(targetDate: Date, projectId?: string): Promise<Task[]> {
     const userId = await this.userDetailsService.getUserId();
     const start = targetDate;
     const end = addDays(targetDate, 1);
@@ -38,6 +38,8 @@ export class TaskProviderServiceImpl implements ITaskProviderService {
       .map((plan) => plan.taskId)
       .filter((taskId): taskId is string => taskId != null);
     const tasks = await this.taskService.getUncompletedByPriority();
-    return tasks.filter((task) => !schduledTaskIds.includes(task.id));
+    return tasks
+      .filter((task) => !schduledTaskIds.includes(task.id))
+      .filter((task) => (projectId ? task.projectId == projectId : true));
   }
 }

--- a/src/main/services/__tests__/TaskProviderServiceImpl.test.ts
+++ b/src/main/services/__tests__/TaskProviderServiceImpl.test.ts
@@ -1,0 +1,138 @@
+import { EventEntryFixture } from '@shared/data/__tests__/EventEntryFixture';
+import { IEventEntryService } from '../IEventEntryService';
+import { ITaskProviderService } from '../ITaskProviderService';
+import { ITaskService } from '../ITaskService';
+import { IUserDetailsService } from '../IUserDetailsService';
+import { TaskProviderServiceImpl } from '../TaskProviderServiceImpl';
+import { EventEntryServiceMockBuilder } from './__mocks__/EventEntryServiceMockBuilder';
+import { TaskServiceMockBuilder } from './__mocks__/TaskServiceMockBuilder';
+import { UserDetailsServiceMockBuilder } from './__mocks__/UserDetailsServiceMockBuilder';
+import { TaskFixture } from '@shared/data/__tests__/TaskFixture';
+import { addDays } from 'date-fns';
+import { EVENT_TYPE } from '@shared/data/EventEntry';
+
+describe('TaskProviderServiceImpl', () => {
+  let service: ITaskProviderService;
+  let userDetailService: IUserDetailsService;
+  let eventEntryService: IEventEntryService;
+  let taskService: ITaskService;
+
+  const userId = 'test user';
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    userDetailService = new UserDetailsServiceMockBuilder().withGetUserId(userId).build();
+    eventEntryService = new EventEntryServiceMockBuilder().build();
+    taskService = new TaskServiceMockBuilder().build();
+    service = new TaskProviderServiceImpl(userDetailService, eventEntryService, taskService);
+  });
+
+  describe('getTasksForAllocation', () => {
+    describe('パラメータを元に各サービスの入力が割り当てられているかのテスト。', () => {
+      it('eventEntryService.list', async () => {
+        const targetDate = new Date('2025-04-01T10:00:00+0900');
+        const expected = {
+          start: targetDate,
+          end: addDays(targetDate, 1),
+        };
+        jest.spyOn(eventEntryService, 'list').mockResolvedValue([]);
+        jest.spyOn(taskService, 'getUncompletedByPriority').mockResolvedValue([]);
+        // memo: projectId はサービスのパラメータとは関係ないので省略する。
+        await service.getTasksForAllocation(targetDate);
+        expect(eventEntryService.list).toHaveBeenCalledWith(userId, expected.start, expected.end);
+      });
+    });
+
+    describe('返り値のテスト', () => {
+      const targetDate = new Date('2025-01-01T10:00:00+0900');
+      const testCases = [
+        {
+          description:
+            'projectId が undefined のとき予定・共有イベントの taskId に合致しない Task を返す。',
+          projectId: undefined,
+          eventEntries: [
+            EventEntryFixture.default({
+              eventType: EVENT_TYPE.PLAN,
+              taskId: 't1',
+            }),
+            EventEntryFixture.default({
+              eventType: EVENT_TYPE.SHARED,
+              taskId: 't2',
+            }),
+          ],
+          tasks: [
+            TaskFixture.default({
+              id: 't1',
+              projectId: 'p1',
+            }),
+            TaskFixture.default({
+              id: 't2',
+              projectId: 'p2',
+            }),
+            TaskFixture.default({
+              id: 't3',
+              projectId: 'p3',
+            }),
+          ],
+          expected: {
+            tasks: [
+              TaskFixture.default({
+                id: 't3',
+                projectId: 'p3',
+              }),
+            ],
+          },
+        },
+        {
+          description:
+            'projectId が引数に渡されているとき projectId に合致しイベントの taskId に合致しない Task を返す。',
+          projectId: 'p1',
+          eventEntries: [
+            EventEntryFixture.default({
+              eventType: EVENT_TYPE.PLAN,
+              taskId: 't1',
+            }),
+            EventEntryFixture.default({
+              eventType: EVENT_TYPE.PLAN,
+              taskId: 't2',
+            }),
+          ],
+          tasks: [
+            TaskFixture.default({
+              id: 't3',
+              projectId: 'p1',
+            }),
+            TaskFixture.default({
+              id: 't4',
+              projectId: 'p2',
+            }),
+          ],
+          expected: {
+            tasks: [
+              TaskFixture.default({
+                id: 't3',
+                projectId: 'p1',
+              }),
+            ],
+          },
+        },
+      ];
+
+      it.each(testCases)('%s', async (testCase) => {
+        jest.spyOn(eventEntryService, 'list').mockResolvedValue(testCase.eventEntries);
+        jest.spyOn(taskService, 'getUncompletedByPriority').mockResolvedValue(testCase.tasks);
+
+        const tasksForAllocation = await service.getTasksForAllocation(
+          targetDate,
+          testCase.projectId
+        );
+
+        expect(tasksForAllocation).toHaveLength(testCase.expected.tasks.length);
+        for (let i = 0; i < tasksForAllocation.length; i++) {
+          expect(tasksForAllocation[i].id).toEqual(testCase.expected.tasks[i].id);
+          expect(tasksForAllocation[i].projectId).toEqual(testCase.expected.tasks[i].projectId);
+        }
+      });
+    });
+  });
+});

--- a/src/renderer/src/components/timeTable/AutoRegisterProvisionalPlans.tsx
+++ b/src/renderer/src/components/timeTable/AutoRegisterProvisionalPlans.tsx
@@ -1,0 +1,110 @@
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormHelperText,
+  Grid,
+  Paper,
+  styled,
+} from '@mui/material';
+import { useFormManager } from '@renderer/hooks/useFormManager';
+import React from 'react';
+import { Controller } from 'react-hook-form';
+import { ProjectDropdownComponent } from '../project/ProjectDropdownComponent';
+
+const CustomDialogContent = styled(DialogContent)`
+  transition: width 0.5s ease;
+`;
+
+const CustomDialog = styled(Dialog)`
+  & .MuiDialog-paper {
+    transition: transform 0.5s ease, width 0.5s ease;
+  }
+`;
+
+interface AutoRegisterProvisionalPlansProps {
+  isOpen: boolean;
+  onSubmit: (projectId: string) => Promise<void>;
+  onClose: () => Promise<void>;
+}
+
+const AutoRegisterProvisionalPlans = (
+  { isOpen, onSubmit, onClose }: AutoRegisterProvisionalPlansProps,
+  ref
+): JSX.Element => {
+  const methods = useFormManager({ formId: 'auto-register-provisional-plans', isVisible: isOpen });
+  const { handleSubmit, control } = methods;
+
+  const handleFormSubmit = async (data): Promise<void> => {
+    console.log('AutoRegisterProvisionalPlans: ', data);
+    await onSubmit(data.projectId);
+  };
+
+  const handleCloseAutoRegisterProvisionalForm = async (): Promise<void> => {
+    await onClose();
+  };
+
+  return (
+    <CustomDialog
+      ref={ref}
+      open={isOpen}
+      onClose={handleCloseAutoRegisterProvisionalForm}
+      PaperProps={{
+        component: 'form',
+        onSubmit: handleSubmit(handleFormSubmit),
+        style: {
+          maxWidth: 600,
+          transition: 'width 0.5s ease, transform 0.5s ease',
+        },
+      }}
+    >
+      <DialogTitle>
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          予定の自動登録
+        </Box>
+      </DialogTitle>
+      <CustomDialogContent>
+        <Grid container spacing={2}>
+          <Grid item xs={12}>
+            <Paper variant="outlined">
+              <Grid container spacing={2} padding={2}>
+                <Grid item xs={12}>
+                  <Controller
+                    name={`projectId`}
+                    control={control}
+                    render={({ field: { onChange } }): JSX.Element => (
+                      <FormControl component="fieldset">
+                        <ProjectDropdownComponent onChange={onChange} />
+                        <FormHelperText>
+                          予定登録を行いたいプロジェクトを指定してください。
+                        </FormHelperText>
+                      </FormControl>
+                    )}
+                  />
+                </Grid>
+              </Grid>
+            </Paper>
+          </Grid>
+        </Grid>
+      </CustomDialogContent>
+      <DialogActions>
+        <Button type="submit" color="primary" variant="contained">
+          仮予定を登録
+        </Button>
+        <Button
+          onClick={handleCloseAutoRegisterProvisionalForm}
+          color="secondary"
+          variant="contained"
+        >
+          キャンセル
+        </Button>
+      </DialogActions>
+    </CustomDialog>
+  );
+};
+
+export default React.forwardRef(AutoRegisterProvisionalPlans);

--- a/src/renderer/src/components/timeTable/AutoRegisterProvisionalPlansForm.tsx
+++ b/src/renderer/src/components/timeTable/AutoRegisterProvisionalPlansForm.tsx
@@ -32,7 +32,7 @@ interface AutoRegisterProvisionalPlansProps {
   onClose: () => Promise<void>;
 }
 
-const AutoRegisterProvisionalPlans = (
+const AutoRegisterProvisionalPlansForm = (
   { isOpen, onSubmit, onClose }: AutoRegisterProvisionalPlansProps,
   ref
 ): JSX.Element => {
@@ -107,4 +107,4 @@ const AutoRegisterProvisionalPlans = (
   );
 };
 
-export default React.forwardRef(AutoRegisterProvisionalPlans);
+export default React.forwardRef(AutoRegisterProvisionalPlansForm);

--- a/src/renderer/src/components/timeTable/EventEntryForm.tsx
+++ b/src/renderer/src/components/timeTable/EventEntryForm.tsx
@@ -76,17 +76,20 @@ const logger = getLogger('EventEntryForm');
  * @param {EventEntryFormProps} props - コンポーネントのプロパティ。
  * @returns {JSX.Element} レンダリング結果。
  */
-const EventEntryForm = ({
-  isOpen,
-  mode,
-  eventType,
-  targetDate,
-  startHour = 0,
-  eventEntry,
-  onSubmit,
-  onClose,
-  onDelete,
-}: EventEntryFormProps): JSX.Element => {
+const EventEntryForm = (
+  {
+    isOpen,
+    mode,
+    eventType,
+    targetDate,
+    startHour = 0,
+    eventEntry,
+    onSubmit,
+    onClose,
+    onDelete,
+  }: EventEntryFormProps,
+  ref
+): JSX.Element => {
   logger.info('EventEntryForm', isOpen, eventEntry);
   const defaultValues = { ...eventEntry };
   const targetDateTime = targetDate?.getTime();
@@ -238,6 +241,7 @@ const EventEntryForm = ({
   return (
     <FormProvider {...methods}>
       <CustomDialog
+        ref={ref}
         open={isOpen}
         onClose={handleCloseEventEntryForm}
         PaperProps={{

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -27,7 +27,7 @@ import { getLogger } from '@renderer/utils/LoggerUtil';
 import ExtraAllocationForm from './ExtraAllocationForm';
 import { useAutoRegistrationPlan } from '@renderer/hooks/useAutoRegistrationPlan';
 import { TimeTableDrawer } from './TimeTableDrawer';
-import AutoRegisterProvisionalPlans from './AutoRegisterProvisionalPlans';
+import AutoRegisterProvisionalPlansForm from './AutoRegisterProvisionalPlansForm';
 
 const logger = getLogger('TimeTable');
 
@@ -459,7 +459,7 @@ const TimeTable = (): JSX.Element => {
           onClose={handleCloseExtraAllocationForm}
         />
 
-        <AutoRegisterProvisionalPlans
+        <AutoRegisterProvisionalPlansForm
           isOpen={isOpenAutoRegisterProvisionalPlans}
           onSubmit={handleSubmitAutoRegisterProvisionalPlans}
           onClose={handleCloseAutoRegisterProvisionalPlans}

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -27,6 +27,7 @@ import { getLogger } from '@renderer/utils/LoggerUtil';
 import ExtraAllocationForm from './ExtraAllocationForm';
 import { useAutoRegistrationPlan } from '@renderer/hooks/useAutoRegistrationPlan';
 import { TimeTableDrawer } from './TimeTableDrawer';
+import AutoRegisterProvisionalPlans from './AutoRegisterProvisionalPlans';
 
 const logger = getLogger('TimeTable');
 
@@ -61,6 +62,7 @@ const TimeTable = (): JSX.Element => {
   const theme = useTheme();
 
   const [isOpenEventEntryForm, setEventEntryFormOpen] = useState(false);
+  const [isOpenAutoRegisterProvisionalPlans, setAutoRegisterProvisionalPlansOpen] = useState(false);
   const [selectedHour, setSelectedHour] = useState(0);
   const [selectedEventType, setSelectedEventType] = useState<EVENT_TYPE>(EVENT_TYPE.PLAN);
   const [selectedFormMode, setFormMode] = useState<FORM_MODE>(FORM_MODE.NEW);
@@ -176,6 +178,18 @@ const TimeTable = (): JSX.Element => {
       // 日付は1日の開始時刻で保存する
       setSelectedDate(getStartDate(date, startHourLocal));
     }
+  };
+
+  const handleSubmitAutoRegisterProvisionalPlans = async (projectId): Promise<void> => {
+    if (selectedDate == null) {
+      return;
+    }
+    handleAutoRegisterProvisionalPlans(selectedDate, projectId);
+    setAutoRegisterProvisionalPlansOpen(false);
+  };
+
+  const handleCloseAutoRegisterProvisionalPlans = async (): Promise<void> => {
+    setAutoRegisterProvisionalPlansOpen(false);
   };
 
   const handleAutoRegisterProvisionalActuals = (): void => {
@@ -298,7 +312,7 @@ const TimeTable = (): JSX.Element => {
       : []),
     {
       text: '予定の自動登録',
-      action: (): void => handleAutoRegisterProvisionalPlans(selectedDate),
+      action: (): void => setAutoRegisterProvisionalPlansOpen(true),
     },
     {
       text: '仮予定の本登録',
@@ -443,6 +457,12 @@ const TimeTable = (): JSX.Element => {
             return handleConfirmExtraAllocation(selectedDate, extraAllocation);
           }}
           onClose={handleCloseExtraAllocationForm}
+        />
+
+        <AutoRegisterProvisionalPlans
+          isOpen={isOpenAutoRegisterProvisionalPlans}
+          onSubmit={handleSubmitAutoRegisterProvisionalPlans}
+          onClose={handleCloseAutoRegisterProvisionalPlans}
         />
       </SelectedDateContext.Provider>
     </>

--- a/src/renderer/src/hooks/useAutoRegistrationPlan.ts
+++ b/src/renderer/src/hooks/useAutoRegistrationPlan.ts
@@ -1,4 +1,7 @@
-import { IPlanAutoRegistrationProxy } from '@renderer/services/IPlanAutoRegistrationProxy';
+import {
+  IPlanAutoRegistrationProxy,
+  PlanAutoRegistrationParams,
+} from '@renderer/services/IPlanAutoRegistrationProxy';
 import rendererContainer from '../inversify.config';
 import { TYPES } from '@renderer/types';
 import { OverrunTask } from '@shared/data/OverrunTask';
@@ -12,10 +15,10 @@ type useAutoRegistrationPlanProps = {
 type UseAutoRegistrationPlanResult = {
   overrunTasks: OverrunTask[];
   isFormOpen: boolean;
-  handleAutoRegisterProvisional: (selectedDate?: Date, projectId?: string) => void;
-  handleAutoRegisterConfirm: (selectedDate?: Date) => void;
-  handleDeleteProvisional: (selectedDate?: Date) => void;
-  handleConfirmExtraAllocation: (selectedDate: Date, extraAllocation: Map<string, number>) => void;
+  handleAutoRegisterProvisional: (targetDate?: Date, projectId?: string) => void;
+  handleAutoRegisterConfirm: (targetDate?: Date) => void;
+  handleDeleteProvisional: (targetDate?: Date) => void;
+  handleConfirmExtraAllocation: (targetDate: Date, taskExtraHours: Map<string, number>) => void;
   handleCloseForm: () => void;
 };
 
@@ -29,13 +32,13 @@ export const useAutoRegistrationPlan = ({
   const autoRegisterPlanService = rendererContainer.get<IPlanAutoRegistrationProxy>(
     TYPES.PlanAutoRegistrationProxy
   );
-  const handleAutoRegisterProvisional = (selectedDate?: Date, projectId?: string): void => {
+  const handleAutoRegisterProvisional = (targetDate?: Date, projectId?: string): void => {
     if (logger.isDebugEnabled())
-      logger.debug('handleAutoRegisterProvisional', selectedDate, projectId);
-    if (selectedDate == null) {
+      logger.debug('handleAutoRegisterProvisional', targetDate, projectId);
+    if (targetDate == null) {
       return;
     }
-    autoRegisterPlan(selectedDate, undefined, projectId);
+    autoRegisterPlan({ targetDate, projectId });
   };
 
   const handleAutoRegisterConfirm = (selectedDate?: Date): void => {
@@ -61,12 +64,12 @@ export const useAutoRegistrationPlan = ({
   };
 
   const handleConfirmExtraAllocation = async (
-    selectedDate: Date,
-    extraAllocation: Map<string, number>
+    targetDate: Date,
+    taskExtraHours: Map<string, number>
   ): Promise<void> => {
     if (logger.isDebugEnabled())
-      logger.debug('handleConfirmExtraAllocationForm', selectedDate, extraAllocation);
-    autoRegisterPlan(selectedDate, extraAllocation);
+      logger.debug('handleConfirmExtraAllocationForm', targetDate, taskExtraHours);
+    autoRegisterPlan({ targetDate, taskExtraHours });
     setFormOpen(false);
     // 確定時、追加工数フォームが閉じる前に overrunTask が空になって、一瞬中身のないフォームが映ってしまう。
     // 空にしなくとも動作はするので、ひとまずコメントアウトで対応する。
@@ -80,16 +83,16 @@ export const useAutoRegistrationPlan = ({
     // setOverrunTasks([]);
   };
 
-  const autoRegisterPlan = async (
-    selectedDate: Date,
-    extraAllocation?: Map<string, number>,
-    projectId?: string
-  ): Promise<void> => {
-    const result = await autoRegisterPlanService.autoRegisterProvisonal(
-      selectedDate,
-      extraAllocation,
-      projectId
-    );
+  const autoRegisterPlan = async ({
+    targetDate,
+    projectId,
+    taskExtraHours = new Map<string, number>(),
+  }: PlanAutoRegistrationParams): Promise<void> => {
+    const result = await autoRegisterPlanService.autoRegisterProvisonal({
+      targetDate,
+      projectId,
+      taskExtraHours,
+    });
     if (result.success) {
       refreshEventEntries();
     } else if (result.overrunTasks) {

--- a/src/renderer/src/hooks/useAutoRegistrationPlan.ts
+++ b/src/renderer/src/hooks/useAutoRegistrationPlan.ts
@@ -81,13 +81,10 @@ export const useAutoRegistrationPlan = ({
   };
 
   const autoRegisterPlan = async (
-    selectedDate?: Date,
+    selectedDate: Date,
     extraAllocation?: Map<string, number>,
     projectId?: string
   ): Promise<void> => {
-    if (selectedDate == null) {
-      return;
-    }
     const result = await autoRegisterPlanService.autoRegisterProvisonal(
       selectedDate,
       extraAllocation,

--- a/src/renderer/src/services/IPlanAutoRegistrationProxy.ts
+++ b/src/renderer/src/services/IPlanAutoRegistrationProxy.ts
@@ -3,7 +3,8 @@ import { PlanAutoRegistrationResult } from '@shared/data/PlanAutoRegistrationRes
 export interface IPlanAutoRegistrationProxy {
   autoRegisterProvisonal(
     targetDate: Date,
-    taskExtraHours?: Map<string, number>
+    taskExtraHours?: Map<string, number>,
+    projectId?: string
   ): Promise<PlanAutoRegistrationResult>;
   confirmRegistration(targetDate: Date): Promise<void>;
   deleteProvisional(targetDate: Date): Promise<void>;

--- a/src/renderer/src/services/IPlanAutoRegistrationProxy.ts
+++ b/src/renderer/src/services/IPlanAutoRegistrationProxy.ts
@@ -1,11 +1,13 @@
 import { PlanAutoRegistrationResult } from '@shared/data/PlanAutoRegistrationResult';
 
+export interface PlanAutoRegistrationParams {
+  targetDate: Date;
+  projectId?: string;
+  taskExtraHours?: Map<string, number>;
+}
+
 export interface IPlanAutoRegistrationProxy {
-  autoRegisterProvisonal(
-    targetDate: Date,
-    taskExtraHours?: Map<string, number>,
-    projectId?: string
-  ): Promise<PlanAutoRegistrationResult>;
+  autoRegisterProvisonal(params: PlanAutoRegistrationParams): Promise<PlanAutoRegistrationResult>;
   confirmRegistration(targetDate: Date): Promise<void>;
   deleteProvisional(targetDate: Date): Promise<void>;
 }

--- a/src/renderer/src/services/PlanAutoRegistrationProxy.ts
+++ b/src/renderer/src/services/PlanAutoRegistrationProxy.ts
@@ -8,13 +8,15 @@ import { PlanAutoRegistrationResult } from '@shared/data/PlanAutoRegistrationRes
 export class PlanAutoRegistrationProxy implements IPlanAutoRegistrationProxy {
   async autoRegisterProvisonal(
     targetDate: Date,
-    taskExtraHours?: Map<string, number>
+    taskExtraHours?: Map<string, number>,
+    projectId?: string
   ): Promise<PlanAutoRegistrationResult> {
     return await handleIpcOperation(async () => {
       return await window.electron.ipcRenderer.invoke(
         IpcChannel.AUTO_REGISTER_PROVISIONAL_PLANS,
         targetDate,
-        taskExtraHours
+        taskExtraHours,
+        projectId
       );
     });
   }

--- a/src/renderer/src/services/PlanAutoRegistrationProxy.ts
+++ b/src/renderer/src/services/PlanAutoRegistrationProxy.ts
@@ -1,16 +1,19 @@
 import { injectable } from 'inversify';
-import { IPlanAutoRegistrationProxy } from './IPlanAutoRegistrationProxy';
+import {
+  IPlanAutoRegistrationProxy,
+  PlanAutoRegistrationParams,
+} from './IPlanAutoRegistrationProxy';
 import { handleIpcOperation } from './ipcErrorHandling';
 import { IpcChannel } from '@shared/constants';
 import { PlanAutoRegistrationResult } from '@shared/data/PlanAutoRegistrationResult';
 
 @injectable()
 export class PlanAutoRegistrationProxy implements IPlanAutoRegistrationProxy {
-  async autoRegisterProvisonal(
-    targetDate: Date,
-    taskExtraHours?: Map<string, number>,
-    projectId?: string
-  ): Promise<PlanAutoRegistrationResult> {
+  async autoRegisterProvisonal({
+    targetDate,
+    projectId,
+    taskExtraHours = new Map<string, number>(),
+  }: PlanAutoRegistrationParams): Promise<PlanAutoRegistrationResult> {
     return await handleIpcOperation(async () => {
       return await window.electron.ipcRenderer.invoke(
         IpcChannel.AUTO_REGISTER_PROVISIONAL_PLANS,


### PR DESCRIPTION
# チケット

#272 

# 実装概要

* 予定の自動登録のダイアログを追加
    * タイムラインのボタンを押下したときにダイアログを表示するように修正
    * プロジェクトを選択し、予定の自動登録を実行するように修正

* EventEntryformの軽微なエラーを修正