### PR TITLE
feat: 予定の自動登録で、登録タスクのプロジェクトを指定できるようにする(mainプロセス)

### DIFF
--- a/src/main/ipc/PlanAutoRegistrationServiceHandlerImpl.ts
+++ b/src/main/ipc/PlanAutoRegistrationServiceHandlerImpl.ts
@@ -25,11 +25,11 @@ export class PlanAutoRegistrationServiceHandlerImpl implements IIpcHandlerInitia
     );
 
     ipcMain.handle(IpcChannel.CONFIRM_PLAN_REGISTRATION, async (_event, targetDate) => {
-      return await this.planAutoRegistrationService.confirmRegistration({ targetDate: targetDate });
+      return await this.planAutoRegistrationService.confirmRegistration(targetDate);
     });
 
     ipcMain.handle(IpcChannel.DELETE_PROVISONAL_PLANS, async (_event, targetDate) => {
-      return await this.planAutoRegistrationService.deleteProvisional({ targetDate: targetDate });
+      return await this.planAutoRegistrationService.deleteProvisional(targetDate);
     });
   }
 }

--- a/src/main/ipc/PlanAutoRegistrationServiceHandlerImpl.ts
+++ b/src/main/ipc/PlanAutoRegistrationServiceHandlerImpl.ts
@@ -18,8 +18,8 @@ export class PlanAutoRegistrationServiceHandlerImpl implements IIpcHandlerInitia
       async (_event, targetDate, taskExtraHours?, projectId?) => {
         return await this.planAutoRegistrationService.autoRegisterProvisional({
           targetDate: targetDate,
-          taskExtraHours: taskExtraHours,
           projectId: projectId,
+          taskExtraHours: taskExtraHours,
         });
       }
     );

--- a/src/main/ipc/PlanAutoRegistrationServiceHandlerImpl.ts
+++ b/src/main/ipc/PlanAutoRegistrationServiceHandlerImpl.ts
@@ -15,20 +15,21 @@ export class PlanAutoRegistrationServiceHandlerImpl implements IIpcHandlerInitia
   init(): void {
     ipcMain.handle(
       IpcChannel.AUTO_REGISTER_PROVISIONAL_PLANS,
-      async (_event, targetDate, taskExtraHours?) => {
-        return await this.planAutoRegistrationService.autoRegisterProvisional(
-          targetDate,
-          taskExtraHours
-        );
+      async (_event, targetDate, taskExtraHours?, projectId?) => {
+        return await this.planAutoRegistrationService.autoRegisterProvisional({
+          targetDate: targetDate,
+          taskExtraHours: taskExtraHours,
+          projectId: projectId,
+        });
       }
     );
 
     ipcMain.handle(IpcChannel.CONFIRM_PLAN_REGISTRATION, async (_event, targetDate) => {
-      return await this.planAutoRegistrationService.confirmRegistration(targetDate);
+      return await this.planAutoRegistrationService.confirmRegistration({ targetDate: targetDate });
     });
 
     ipcMain.handle(IpcChannel.DELETE_PROVISONAL_PLANS, async (_event, targetDate) => {
-      return await this.planAutoRegistrationService.deleteProvisional(targetDate);
+      return await this.planAutoRegistrationService.deleteProvisional({ targetDate: targetDate });
     });
   }
 }

--- a/src/main/services/IPlanAutoRegistrationService.ts
+++ b/src/main/services/IPlanAutoRegistrationService.ts
@@ -8,6 +8,6 @@ export interface PlanAutoRegistrationParams {
 
 export interface IPlanAutoRegistrationService {
   autoRegisterProvisional(params: PlanAutoRegistrationParams): Promise<PlanAutoRegistrationResult>;
-  confirmRegistration(params: PlanAutoRegistrationParams): Promise<void>;
-  deleteProvisional(params: PlanAutoRegistrationParams): Promise<void>;
+  confirmRegistration(targetDate: Date): Promise<void>;
+  deleteProvisional(targetDate: Date): Promise<void>;
 }

--- a/src/main/services/IPlanAutoRegistrationService.ts
+++ b/src/main/services/IPlanAutoRegistrationService.ts
@@ -2,8 +2,8 @@ import { PlanAutoRegistrationResult } from '@shared/data/PlanAutoRegistrationRes
 
 export interface PlanAutoRegistrationParams {
   targetDate: Date;
-  taskExtraHours?: Map<string, number>;
   projectId?: string;
+  taskExtraHours?: Map<string, number>;
 }
 
 export interface IPlanAutoRegistrationService {

--- a/src/main/services/IPlanAutoRegistrationService.ts
+++ b/src/main/services/IPlanAutoRegistrationService.ts
@@ -1,10 +1,13 @@
 import { PlanAutoRegistrationResult } from '@shared/data/PlanAutoRegistrationResult';
 
+export interface PlanAutoRegistrationParams {
+  targetDate: Date;
+  taskExtraHours?: Map<string, number>;
+  projectId?: string;
+}
+
 export interface IPlanAutoRegistrationService {
-  autoRegisterProvisional(
-    targetDate: Date,
-    taskExtraHours?: Map<string, number>
-  ): Promise<PlanAutoRegistrationResult>;
-  confirmRegistration(targetDate: Date): Promise<void>;
-  deleteProvisional(targetDate: Date): Promise<void>;
+  autoRegisterProvisional(params: PlanAutoRegistrationParams): Promise<PlanAutoRegistrationResult>;
+  confirmRegistration(params: PlanAutoRegistrationParams): Promise<void>;
+  deleteProvisional(params: PlanAutoRegistrationParams): Promise<void>;
 }

--- a/src/main/services/ITaskProviderService.ts
+++ b/src/main/services/ITaskProviderService.ts
@@ -1,5 +1,5 @@
 import { Task } from '@shared/data/Task';
 
 export interface ITaskProviderService {
-  getTasksForAllocation(targetDate: Date): Promise<Task[]>;
+  getTasksForAllocation(targetDate: Date, projectId?: string): Promise<Task[]>;
 }

--- a/src/main/services/PlanAutoRegistrationServiceImpl.ts
+++ b/src/main/services/PlanAutoRegistrationServiceImpl.ts
@@ -61,7 +61,10 @@ export class PlanAutoRegistrationServiceImpl implements IPlanAutoRegistrationSer
     const freeSlots = await this.planAvailableTimeSlotService.calculateAvailableTimeSlot(
       params.targetDate
     );
-    const tasks = await this.taskProviderService.getTasksForAllocation(params.targetDate);
+    const tasks = await this.taskProviderService.getTasksForAllocation(
+      params.targetDate,
+      params.projectId
+    );
     const taskAllocationResult = await this.taskAllocationService.allocate(
       freeSlots,
       tasks,

--- a/src/main/services/PlanAutoRegistrationServiceImpl.ts
+++ b/src/main/services/PlanAutoRegistrationServiceImpl.ts
@@ -91,8 +91,8 @@ export class PlanAutoRegistrationServiceImpl implements IPlanAutoRegistrationSer
    *
    * @param targetDate
    */
-  async confirmRegistration(params: PlanAutoRegistrationParams): Promise<void> {
-    const provisionalPlans = await this.getProvisionalPlans(params.targetDate);
+  async confirmRegistration(targetDate: Date): Promise<void> {
+    const provisionalPlans = await this.getProvisionalPlans(targetDate);
     this.eventEntryService.bulkUpsert(
       provisionalPlans.map((provisionalActual) => ({ ...provisionalActual, isProvisional: false }))
     );
@@ -103,8 +103,8 @@ export class PlanAutoRegistrationServiceImpl implements IPlanAutoRegistrationSer
    *
    * @param targetDate
    */
-  async deleteProvisional(params: PlanAutoRegistrationParams): Promise<void> {
-    const provisionalPlans = await this.getProvisionalPlans(params.targetDate);
+  async deleteProvisional(targetDate: Date): Promise<void> {
+    const provisionalPlans = await this.getProvisionalPlans(targetDate);
     this.eventEntryService.bulkLogicalDelete(provisionalPlans.map((plan) => plan.id));
   }
 }

--- a/src/main/services/TaskProviderServiceImpl.ts
+++ b/src/main/services/TaskProviderServiceImpl.ts
@@ -26,7 +26,7 @@ export class TaskProviderServiceImpl implements ITaskProviderService {
     @inject(TYPES.TaskService)
     private readonly taskService: ITaskService
   ) {}
-  // TODO: 単体テストの実装
+
   async getTasksForAllocation(targetDate: Date, projectId?: string): Promise<Task[]> {
     const userId = await this.userDetailsService.getUserId();
     const start = targetDate;
@@ -40,6 +40,6 @@ export class TaskProviderServiceImpl implements ITaskProviderService {
     const tasks = await this.taskService.getUncompletedByPriority();
     return tasks
       .filter((task) => !schduledTaskIds.includes(task.id))
-      .filter((task) => task.projectId == projectId);
+      .filter((task) => (projectId ? task.projectId == projectId : true));
   }
 }

--- a/src/main/services/TaskProviderServiceImpl.ts
+++ b/src/main/services/TaskProviderServiceImpl.ts
@@ -27,7 +27,7 @@ export class TaskProviderServiceImpl implements ITaskProviderService {
     private readonly taskService: ITaskService
   ) {}
   // TODO: 単体テストの実装
-  async getTasksForAllocation(targetDate: Date): Promise<Task[]> {
+  async getTasksForAllocation(targetDate: Date, projectId?: string): Promise<Task[]> {
     const userId = await this.userDetailsService.getUserId();
     const start = targetDate;
     const end = addDays(targetDate, 1);
@@ -38,6 +38,8 @@ export class TaskProviderServiceImpl implements ITaskProviderService {
       .map((plan) => plan.taskId)
       .filter((taskId): taskId is string => taskId != null);
     const tasks = await this.taskService.getUncompletedByPriority();
-    return tasks.filter((task) => !schduledTaskIds.includes(task.id));
+    return tasks
+      .filter((task) => !schduledTaskIds.includes(task.id))
+      .filter((task) => task.projectId == projectId);
   }
 }

--- a/src/main/services/__tests__/TaskProviderServiceImpl.test.ts
+++ b/src/main/services/__tests__/TaskProviderServiceImpl.test.ts
@@ -1,0 +1,138 @@
+import { EventEntryFixture } from '@shared/data/__tests__/EventEntryFixture';
+import { IEventEntryService } from '../IEventEntryService';
+import { ITaskProviderService } from '../ITaskProviderService';
+import { ITaskService } from '../ITaskService';
+import { IUserDetailsService } from '../IUserDetailsService';
+import { TaskProviderServiceImpl } from '../TaskProviderServiceImpl';
+import { EventEntryServiceMockBuilder } from './__mocks__/EventEntryServiceMockBuilder';
+import { TaskServiceMockBuilder } from './__mocks__/TaskServiceMockBuilder';
+import { UserDetailsServiceMockBuilder } from './__mocks__/UserDetailsServiceMockBuilder';
+import { TaskFixture } from '@shared/data/__tests__/TaskFixture';
+import { addDays } from 'date-fns';
+import { EVENT_TYPE } from '@shared/data/EventEntry';
+
+describe('TaskProviderServiceImpl', () => {
+  let service: ITaskProviderService;
+  let userDetailService: IUserDetailsService;
+  let eventEntryService: IEventEntryService;
+  let taskService: ITaskService;
+
+  const userId = 'test user';
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    userDetailService = new UserDetailsServiceMockBuilder().withGetUserId(userId).build();
+    eventEntryService = new EventEntryServiceMockBuilder().build();
+    taskService = new TaskServiceMockBuilder().build();
+    service = new TaskProviderServiceImpl(userDetailService, eventEntryService, taskService);
+  });
+
+  describe('getTasksForAllocation', () => {
+    describe('パラメータを元に各サービスの入力が割り当てられているかのテスト。', () => {
+      it('eventEntryService.list', async () => {
+        const targetDate = new Date('2025-04-01T10:00:00+0900');
+        const expected = {
+          start: targetDate,
+          end: addDays(targetDate, 1),
+        };
+        jest.spyOn(eventEntryService, 'list').mockResolvedValue([]);
+        jest.spyOn(taskService, 'getUncompletedByPriority').mockResolvedValue([]);
+        // memo: projectId はサービスのパラメータとは関係ないので省略する。
+        await service.getTasksForAllocation(targetDate);
+        expect(eventEntryService.list).toHaveBeenCalledWith(userId, expected.start, expected.end);
+      });
+    });
+
+    describe('返り値のテスト', () => {
+      const targetDate = new Date('2025-01-01T10:00:00+0900');
+      const testCases = [
+        {
+          description:
+            'projectId が undefined のとき予定・共有イベントの taskId に合致しない Task を返す。',
+          projectId: undefined,
+          eventEntries: [
+            EventEntryFixture.default({
+              eventType: EVENT_TYPE.PLAN,
+              taskId: 't1',
+            }),
+            EventEntryFixture.default({
+              eventType: EVENT_TYPE.SHARED,
+              taskId: 't2',
+            }),
+          ],
+          tasks: [
+            TaskFixture.default({
+              id: 't1',
+              projectId: 'p1',
+            }),
+            TaskFixture.default({
+              id: 't2',
+              projectId: 'p2',
+            }),
+            TaskFixture.default({
+              id: 't3',
+              projectId: 'p3',
+            }),
+          ],
+          expected: {
+            tasks: [
+              TaskFixture.default({
+                id: 't3',
+                projectId: 'p3',
+              }),
+            ],
+          },
+        },
+        {
+          description:
+            'projectId が引数に渡されているとき projectId に合致しイベントの taskId に合致しない Task を返す。',
+          projectId: 'p1',
+          eventEntries: [
+            EventEntryFixture.default({
+              eventType: EVENT_TYPE.PLAN,
+              taskId: 't1',
+            }),
+            EventEntryFixture.default({
+              eventType: EVENT_TYPE.PLAN,
+              taskId: 't2',
+            }),
+          ],
+          tasks: [
+            TaskFixture.default({
+              id: 't3',
+              projectId: 'p1',
+            }),
+            TaskFixture.default({
+              id: 't4',
+              projectId: 'p2',
+            }),
+          ],
+          expected: {
+            tasks: [
+              TaskFixture.default({
+                id: 't3',
+                projectId: 'p1',
+              }),
+            ],
+          },
+        },
+      ];
+
+      it.each(testCases)('%s', async (testCase) => {
+        jest.spyOn(eventEntryService, 'list').mockResolvedValue(testCase.eventEntries);
+        jest.spyOn(taskService, 'getUncompletedByPriority').mockResolvedValue(testCase.tasks);
+
+        const tasksForAllocation = await service.getTasksForAllocation(
+          targetDate,
+          testCase.projectId
+        );
+
+        expect(tasksForAllocation).toHaveLength(testCase.expected.tasks.length);
+        for (let i = 0; i < tasksForAllocation.length; i++) {
+          expect(tasksForAllocation[i].id).toEqual(testCase.expected.tasks[i].id);
+          expect(tasksForAllocation[i].projectId).toEqual(testCase.expected.tasks[i].projectId);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
# チケット

#272 

# 実装概要

* 予定の自動登録で割り当てるタスクを返すクラスの修正
    * パラメータのprojectIdでタスクのフィルターを行うように修正
    * ユニットテストを追加

* 仮予定の作成クラスの修正
    * 要素名を指定してパラメータを渡すように修正
    * →IPCハンドラーも同様に修正