### PR TITLE
Release 1.0/bugfix/external device flow window

### DIFF
--- a/src/renderer/src/components/settings/AccountSetting.tsx
+++ b/src/renderer/src/components/settings/AccountSetting.tsx
@@ -47,7 +47,6 @@ export const AccountSetting = (): JSX.Element => {
     isAuthenticated: isGitHubAuthenticated,
     authError: githubAuthError,
     userCode: githubUserCode,
-    isOpenUserCodeWindow: isOpenGitHubUserCodeWindow,
     handleAuth: handleGitHubAuth,
     handleShowUserCodeInputWindow: handleGitHubShowWindow,
     handleRevoke: handleGitHubRevoke,
@@ -163,7 +162,6 @@ export const AccountSetting = (): JSX.Element => {
                                 <Button
                                   variant="contained"
                                   color="primary"
-                                  disabled={isOpenGitHubUserCodeWindow}
                                   onClick={handleGitHubShowWindow}
                                 >
                                   コードを入力する

--- a/src/renderer/src/hooks/useGitHubAuth.ts
+++ b/src/renderer/src/hooks/useGitHubAuth.ts
@@ -9,7 +9,6 @@ type UseGitHubAuthResult = {
   isAuthenticated: boolean | null;
   authError: string | null;
   userCode: string | null;
-  isOpenUserCodeWindow: boolean;
   handleAuth: () => Promise<void>;
   handleShowUserCodeInputWindow: () => Promise<void>;
   handleRevoke: () => Promise<void>;
@@ -23,7 +22,6 @@ const useGitHubAuth = (): UseGitHubAuthResult => {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
   const [userCode, setUserCode] = useState<string | null>(null);
-  const [isOpenUserCodeWindow, setUserCodeWindowOpen] = useState<boolean>(false);
   const authProxy = rendererContainer.get<IDeviceFlowAuthProxy>(TYPES.GitHubAuthProxy);
 
   useEffect(() => {
@@ -73,13 +71,11 @@ const useGitHubAuth = (): UseGitHubAuthResult => {
     }
   };
   const handleShowUserCodeInputWindow = async (): Promise<void> => {
-    setUserCodeWindowOpen(true);
     try {
       await authProxy.showUserCodeInputWindow();
     } catch (error) {
       logger.error('Error during user code input', error);
     }
-    setUserCodeWindowOpen(false);
   };
   const handleRevoke = async (): Promise<void> => {
     try {
@@ -97,7 +93,6 @@ const useGitHubAuth = (): UseGitHubAuthResult => {
     isAuthenticated,
     authError,
     userCode,
-    isOpenUserCodeWindow,
     handleAuth,
     handleShowUserCodeInputWindow,
     handleRevoke,


### PR DESCRIPTION
## チケット
#331 
#332 

## 修正内容
- ユーザーコード入力画面を内部ブラウザではなく外部ブラウザで開くように変更
  - 外部ブラウザは開いているかどうかの判定が難しいので、コードを入力するボタンの無効化制御を削除(二重に開けるようにする)
    - ウィンドウが二重に開けるようになったことで、二重起動防止処理が不要になり結果的に#332のバグが解消 