### PR TITLE
fix: IPC通信時にWIndowがない場合はエラーを投げないように修正

### DIFF
--- a/src/main/services/IpcService.ts
+++ b/src/main/services/IpcService.ts
@@ -6,19 +6,22 @@ export class IpcService {
   private window: BrowserWindow | null = null;
 
   hasValidWindow(): boolean {
-    return this.window == null || !this.window.isDestroyed();
+    return this.isValidWindow(this.window);
   }
 
   setWindow(window: BrowserWindow | null): void {
     this.window = window;
   }
 
-  send(channel: string, ...args: unknown[]): void {
-    if (!this.window) {
-      throw new Error('Window not initialized');
+  send(channel: string, ...args: unknown[]): boolean {
+    if (!this.isValidWindow(this.window)) {
+      return false;
     }
-    if (this.hasValidWindow()) {
-      this.window.webContents.send(channel, ...args);
-    }
+    this.window.webContents.send(channel, ...args);
+    return true;
+  }
+
+  private isValidWindow(window: BrowserWindow | null): window is BrowserWindow {
+    return window != null && !window.isDestroyed();
   }
 }

--- a/src/main/services/__tests__/EventNotifyProcessorImpl.test.ts
+++ b/src/main/services/__tests__/EventNotifyProcessorImpl.test.ts
@@ -334,7 +334,9 @@ describe('EventNotifyProcessorImpl', () => {
         },
       ];
       it.each(testCases)('%s', async (t) => {
-        const sendSpy = jest.spyOn(ipcService, 'send').mockImplementation(() => {});
+        const sendSpy = jest.spyOn(ipcService, 'send').mockImplementation(() => {
+          return true;
+        });
         processor.sendNotifyText(t.paramEventEntry, t.paramUserPreference, t.paramChannel);
 
         expect(sendSpy).toHaveBeenCalledWith(t.expectedChannel, t.expectedNotifyText);
@@ -366,7 +368,9 @@ describe('EventNotifyProcessorImpl', () => {
         },
       ];
       it.each(testCases)('%s', async (t) => {
-        const sendSpy = jest.spyOn(ipcService, 'send').mockImplementation(() => {});
+        const sendSpy = jest.spyOn(ipcService, 'send').mockImplementation(() => {
+          return true;
+        });
         const timeSignalTextSpy = jest
           .spyOn(speakTextGenerator, 'timeToText')
           .mockReturnValue(formattedText);

--- a/src/main/services/__tests__/SpeakTimeNotifyProcessorImpl.test.ts
+++ b/src/main/services/__tests__/SpeakTimeNotifyProcessorImpl.test.ts
@@ -103,7 +103,9 @@ describe('SpeakTimeNotifyProcessorImpl', () => {
       },
     ];
     it.each(testCases)('%s', async (t) => {
-      const sendSpy = jest.spyOn(ipcService, 'send').mockImplementation(() => {});
+      const sendSpy = jest.spyOn(ipcService, 'send').mockImplementation(() => {
+        return true;
+      });
 
       await processor.sendSpeakText(t.paramText);
 

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -19,6 +19,7 @@
         "src/shared/*"
       ]
     },
+    "types": ["jest"],
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true


### PR DESCRIPTION
## チケット
#338 

## 修正内容
Dock格納時に、ウィンドウがない状態でIPC通信を送ってエラーになる。(厳密には、ウィンドウの存在チェックでエラーになる)
ウィンドウがないときは、IPC通信をしないかつエラーも起こさないように修正。

- tsconfigの修正は、開発環境のエラーの修正です。(本番には関係ないはずです)