### PR TITLE
fix: タイムラインのアクティビティが即時反映されていない

### DIFF
--- a/src/renderer/src/components/timeTable/ActivitySlot.tsx
+++ b/src/renderer/src/components/timeTable/ActivitySlot.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { addHours } from 'date-fns';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { ActivityUsage } from '@shared/data/ActivityUsage';
@@ -7,13 +7,18 @@ import { useActivityUsage } from '@renderer/hooks/useActivityUsage';
 interface ActivitySlotProps {
   startTime?: Date;
   hourNum: number;
+  activityUpdated: boolean;
 }
 
 /**
  * ActivitySlot はアクティビティの枠にバーチャートを表示する
  *
  */
-export const ActivitySlot = ({ startTime, hourNum }: ActivitySlotProps): JSX.Element => {
+export const ActivitySlot = ({
+  startTime,
+  hourNum,
+  activityUpdated,
+}: ActivitySlotProps): JSX.Element => {
   const startDate = useMemo<Date | undefined>(
     () => (startTime ? addHours(startTime, hourNum) : undefined),
     [hourNum, startTime]
@@ -22,7 +27,12 @@ export const ActivitySlot = ({ startTime, hourNum }: ActivitySlotProps): JSX.Ele
     () => (startTime ? addHours(startTime, hourNum + 1) : undefined),
     [hourNum, startTime]
   );
-  const { activityUsage } = useActivityUsage(startDate, endDate);
+  const { refreshActivityUsage, activityUsage } = useActivityUsage(startDate, endDate);
+
+  // TODO: フラグの変化によって更新を実行しているが、将来的にはrefを呼び出し更新を行う。
+  useEffect(() => {
+    refreshActivityUsage();
+  }, [activityUpdated, refreshActivityUsage]);
 
   const summerizeAsOther = (activityUsage: ActivityUsage[], topN: number): ActivityUsage[] => {
     if (activityUsage.length <= topN) {

--- a/src/renderer/src/components/timeTable/ActivitySlot.tsx
+++ b/src/renderer/src/components/timeTable/ActivitySlot.tsx
@@ -7,17 +7,24 @@ import { useActivityUsage } from '@renderer/hooks/useActivityUsage';
 interface ActivitySlotProps {
   startTime?: Date;
   hourNum: number;
-  activityUpdated: boolean;
+  activityRefreshTrigger: boolean;
 }
 
 /**
  * ActivitySlot はアクティビティの枠にバーチャートを表示する
- *
+ * 
+ * 補足:
+ * - activityRefreshTriggerはタイムラインのイベントが更新されたときにアクティビティを更新するための変数。
+ * - 依存配列にactivityRefreshTriggerを入れることで、
+ *   activityRefreshTriggerが更新されたときにuseEffect内のアクティビティ更新を実行する。
+ * 
+ * TODO:
+ * - activityRefreshTriggerによってアクティビティ更新をしているが、将来的にはrefを親から呼び出し更新を行う。
  */
 export const ActivitySlot = ({
   startTime,
   hourNum,
-  activityUpdated,
+  activityRefreshTrigger,
 }: ActivitySlotProps): JSX.Element => {
   const startDate = useMemo<Date | undefined>(
     () => (startTime ? addHours(startTime, hourNum) : undefined),
@@ -29,10 +36,9 @@ export const ActivitySlot = ({
   );
   const { refreshActivityUsage, activityUsage } = useActivityUsage(startDate, endDate);
 
-  // TODO: フラグの変化によって更新を実行しているが、将来的にはrefを呼び出し更新を行う。
   useEffect(() => {
     refreshActivityUsage();
-  }, [activityUpdated, refreshActivityUsage]);
+  }, [activityRefreshTrigger, refreshActivityUsage]);
 
   const summerizeAsOther = (activityUsage: ActivityUsage[], topN: number): ActivityUsage[] => {
     if (activityUsage.length <= topN) {

--- a/src/renderer/src/components/timeTable/ActivityTableLane.tsx
+++ b/src/renderer/src/components/timeTable/ActivityTableLane.tsx
@@ -4,18 +4,22 @@ import { TimeLaneContainer } from './TimeLane';
 
 interface ActivityTableLaneProps {
   startTime?: Date;
+  activityUpdated: boolean;
 }
 
 /**
  * ActivityTableLane は、タイムラインのアクティビティの列を表示する
  *
  */
-export const ActivityTableLane = ({ startTime }: ActivityTableLaneProps): JSX.Element => {
+export const ActivityTableLane = ({
+  startTime,
+  activityUpdated,
+}: ActivityTableLaneProps): JSX.Element => {
   return (
     <TimeLaneContainer name={'activity'}>
       {Array.from({ length: 24 }).map((_, i, self) => (
         <TimeCell key={i} isBottom={i === self.length - 1} isRight={true}>
-          <ActivitySlot startTime={startTime} hourNum={i} />
+          <ActivitySlot startTime={startTime} hourNum={i} activityUpdated={activityUpdated} />
         </TimeCell>
       ))}
     </TimeLaneContainer>

--- a/src/renderer/src/components/timeTable/ActivityTableLane.tsx
+++ b/src/renderer/src/components/timeTable/ActivityTableLane.tsx
@@ -4,7 +4,7 @@ import { TimeLaneContainer } from './TimeLane';
 
 interface ActivityTableLaneProps {
   startTime?: Date;
-  activityUpdated: boolean;
+  activityRefreshTrigger: boolean;
 }
 
 /**
@@ -13,13 +13,17 @@ interface ActivityTableLaneProps {
  */
 export const ActivityTableLane = ({
   startTime,
-  activityUpdated,
+  activityRefreshTrigger,
 }: ActivityTableLaneProps): JSX.Element => {
   return (
     <TimeLaneContainer name={'activity'}>
       {Array.from({ length: 24 }).map((_, i, self) => (
         <TimeCell key={i} isBottom={i === self.length - 1} isRight={true}>
-          <ActivitySlot startTime={startTime} hourNum={i} activityUpdated={activityUpdated} />
+          <ActivitySlot
+            startTime={startTime}
+            hourNum={i}
+            activityRefreshTrigger={activityRefreshTrigger}
+          />
         </TimeCell>
       ))}
     </TimeLaneContainer>

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -68,7 +68,7 @@ const TimeTable = (): JSX.Element => {
     refreshEventEntries,
   } = useEventEntries(tableStartDateTime);
   const { activityEvents, refreshActivityEntries } = useActivityEvents(tableStartDateTime);
-  const [activityUpdated, setActivityUpdated] = useState(false);
+  const [activityRefreshTrigger, setActivityRefreshTrigger] = useState(false);
   const theme = useTheme();
 
   const [isOpenEventEntryForm, setEventEntryFormOpen] = useState(false);
@@ -118,7 +118,7 @@ const TimeTable = (): JSX.Element => {
     const handler = (): void => {
       if (logger.isDebugEnabled()) logger.debug('recv ACTIVITY_NOTIFY');
       refreshActivityEntries();
-      setActivityUpdated((trigger) => !trigger);
+      setActivityRefreshTrigger((trigger) => !trigger);
     };
     // コンポーネントがマウントされたときに IPC のハンドラを設定
     const unsubscribe = window.electron.ipcRenderer.on(IpcChannel.ACTIVITY_NOTIFY, handler);
@@ -555,7 +555,10 @@ const TimeTable = (): JSX.Element => {
           </Grid>
           <Grid item xs={3}>
             <HeaderCell isRight={true}>アクティビティ</HeaderCell>
-            <ActivityTableLane startTime={tableStartDateTime} activityUpdated={activityUpdated} />
+            <ActivityTableLane
+              startTime={tableStartDateTime}
+              activityRefreshTrigger={activityRefreshTrigger}
+            />
           </Grid>
         </Grid>
       </TimelineContext.Provider>

--- a/src/renderer/src/components/timeTable/TimeTable.tsx
+++ b/src/renderer/src/components/timeTable/TimeTable.tsx
@@ -68,6 +68,7 @@ const TimeTable = (): JSX.Element => {
     refreshEventEntries,
   } = useEventEntries(tableStartDateTime);
   const { activityEvents, refreshActivityEntries } = useActivityEvents(tableStartDateTime);
+  const [activityUpdated, setActivityUpdated] = useState(false);
   const theme = useTheme();
 
   const [isOpenEventEntryForm, setEventEntryFormOpen] = useState(false);
@@ -117,6 +118,7 @@ const TimeTable = (): JSX.Element => {
     const handler = (): void => {
       if (logger.isDebugEnabled()) logger.debug('recv ACTIVITY_NOTIFY');
       refreshActivityEntries();
+      setActivityUpdated((trigger) => !trigger);
     };
     // コンポーネントがマウントされたときに IPC のハンドラを設定
     const unsubscribe = window.electron.ipcRenderer.on(IpcChannel.ACTIVITY_NOTIFY, handler);
@@ -553,7 +555,7 @@ const TimeTable = (): JSX.Element => {
           </Grid>
           <Grid item xs={3}>
             <HeaderCell isRight={true}>アクティビティ</HeaderCell>
-            <ActivityTableLane startTime={tableStartDateTime} />
+            <ActivityTableLane startTime={tableStartDateTime} activityUpdated={activityUpdated} />
           </Grid>
         </Grid>
       </TimelineContext.Provider>


### PR DESCRIPTION
# チケット

#327 

# 実装内容

* タイムラインのアクティビティがEVENT_ENTRY_NOTIFYのメッセージに合わせて更新されるように修正

# TODO

今回の実装では時間の関係でbooleanで実装したが、将来的には親コンポーネントから実行し更新を行いたい