### PR TITLE
fix: 予実フィルターの変更とエラーメッセージの修正

### DIFF
--- a/src/main/services/EventEntrySearchServiceImpl.ts
+++ b/src/main/services/EventEntrySearchServiceImpl.ts
@@ -39,15 +39,20 @@ export class EventEntrySearchServiceImpl implements IEventEntrySearchService {
     private readonly labelService: ILabelService
   ) {}
 
-  async getPlanAndActuals(params: EventEntrySearchParams): Promise<EventEntrySearch[]> {
+  async getPlanAndActuals({
+    start,
+    end,
+    eventType,
+  }: EventEntrySearchParams): Promise<EventEntrySearch[]> {
     const userId = await this.userDetailsService.getUserId();
     const eventEntrys: EventEntry[] = (
-      await this.eventEntryService.list(userId, params.start, params.end)
+      await this.eventEntryService.list(userId, start, end)
     ).filter((event) => !event.deleted);
-    const filteredEvents =
-      params.eventType === EVENT_TYPE.ACTUAL
-        ? eventEntrys.filter((event) => event.eventType === EVENT_TYPE.ACTUAL)
-        : eventEntrys.filter((event) => event.eventType !== EVENT_TYPE.ACTUAL);
+    const filteredEvents = !eventType
+      ? eventEntrys
+      : eventType === EVENT_TYPE.ACTUAL
+      ? eventEntrys.filter((event) => event.eventType === EVENT_TYPE.ACTUAL)
+      : eventEntrys.filter((event) => event.eventType !== EVENT_TYPE.ACTUAL);
     const projects: Project[] = await this.getEventMatchProjects(filteredEvents);
     const categories: Category[] = await this.getEventMatchCategories(filteredEvents);
     const tasks: Task[] = await this.getEventMatchTasks(filteredEvents);

--- a/src/renderer/src/components/planAndActualCsv/PlanAndActualCsvOutput.tsx
+++ b/src/renderer/src/components/planAndActualCsv/PlanAndActualCsvOutput.tsx
@@ -56,7 +56,7 @@ export const PlanAndActualCsvOutput = (): JSX.Element => {
     if (!startDate) throw new Error('startDate is undefined');
     if (!endDate) throw new Error('endDate is undefined');
     if (differenceInDays(addDays(endDate, 1), startDate) > 30) {
-      setWarning('開始日時と終了日時の期間が1カ月以上です');
+      setWarning('開始日時と終了日時の期間が30日を超えています');
       return;
     } else {
       setWarning('');
@@ -135,9 +135,6 @@ export const PlanAndActualCsvOutput = (): JSX.Element => {
               </MenuItem>
               <MenuItem key={'ACTUAL'} value={EVENT_TYPE.ACTUAL}>
                 実績のみ
-              </MenuItem>
-              <MenuItem key={'SHARED'} value={EVENT_TYPE.SHARED}>
-                共有のみ
               </MenuItem>
             </TextField>
           </Grid>


### PR DESCRIPTION
## チケット
#353 

## 修正内容
- 共有のみフィルターを削除
- フィルターなしに実績が含まれるように修正
- 予定のみは、修正前のまま、全ての予定が含まれるようにする(共有のみを消したことでこの仕様の方がが明快になる)
- 1か月以上選択したときのエラーメッセージを、日数表示にして明確化