### PR TITLE
fix: 空のアクティビティが表示される問題の修正

### DIFF
--- a/src/main/services/ActivityServiceImpl.ts
+++ b/src/main/services/ActivityServiceImpl.ts
@@ -30,7 +30,9 @@ export class ActivityServiceImpl implements IActivityService {
 
     for (const winlog of winLogs) {
       // アイドル状態の場合は、アクティビティには含めない
-      if (winlog.pid === SYSTEM_IDLE_PID) {
+      // PID=0はアイドル状態かライブラリのアクセス権限がなくて0を返しているのか判断がつかないが、
+      // いずれにせよbasenameがないので含めない
+      if (winlog.pid === SYSTEM_IDLE_PID || winlog.pid === '0') {
         if (currentEvent) {
           currentEvent = null;
         }


### PR DESCRIPTION
## チケット
#358 

## 修正内容
出現条件がよく分からなかったが、該当のデータはPID 0なのでそれをアクティビティ生成時に無視する処理を追加。