### PR TITLE
fix: GitHubアクティビティの内容表示を改善

### DIFF
--- a/src/renderer/src/services/EventTimeCell.ts
+++ b/src/renderer/src/services/EventTimeCell.ts
@@ -324,6 +324,14 @@ export class GitHubEventTimeCell extends EventTimeCell<GitHubEvent, GitHubEventT
       const p = event.payload;
       summary = `wikiページ`;
       description = JSON.stringify(p);
+    } else if (event.type === 'IssueCommentEvent') {
+      // Issueコメントの作成・編集・削除
+      // payload: ?
+      const p = event.payload;
+      const issue = p.issue as Record<string, unknown>;
+      const comment = p.comment as Record<string, unknown>;
+      summary = `Issueコメント`;
+      description = `${p.action} #${issue.number} ${issue.title ?? ''}: ${comment.body}`;
     } else if (event.type === 'IssuesEvent') {
       // Issueに関連するアクティビティ
       // payload: ?
@@ -353,7 +361,7 @@ export class GitHubEventTimeCell extends EventTimeCell<GitHubEvent, GitHubEventT
       const pr = p.pull_request as Record<string, unknown>;
       const comment = p.comment as Record<string, unknown>;
       summary = `PR コメント`;
-      description = `${p.action} #${p.number} ${pr.title ?? ''}: ${comment.body ?? ''}`;
+      description = `${p.action} #${pr.number} ${pr.title ?? ''}: ${comment.body ?? ''}`;
     } else if (event.type === 'PullRequestReviewThreadEvent') {
       // 解決済みまたは未解決とマークされている pull request のコメント スレッドに関連するアクティビティ
       // payload: ?
@@ -361,7 +369,19 @@ export class GitHubEventTimeCell extends EventTimeCell<GitHubEvent, GitHubEventT
       const pr = p.pull_request as Record<string, unknown>;
       const thread = p.thread as Record<string, unknown>;
       summary = `PR コメント スレッド`;
-      description = `${p.action} #${p.number} ${pr.title ?? ''}: ${JSON.stringify(thread)}`;
+      description = `${p.action} #${pr.number} ${pr.title ?? ''}: ${JSON.stringify(thread)}`;
+    } else if (event.type === 'PullRequestReviewEvent') {
+      // Pull Requestに関連するアクティビティ
+      // payload: ?
+      const p = event.payload;
+      const pr = p.pull_request as Record<string, unknown>;
+      const review = p.review as Record<string, unknown>;
+      summary = `PRレビュー`;
+      if (p.action === 'created') {
+        description = `${p.action} #${pr.number} ${pr.title ?? ''}: ${review.body ?? ''}`;
+      } else {
+        description = `${p.action} #${pr.number} ${pr.title ?? ''}: ${review.body ?? ''}`;
+      }
     } else if (event.type === 'PushEvent') {
       // リポジトリのブランチもしくはタグに、1つ以上のコミットがプッシュされました
       // payload: ?


### PR DESCRIPTION
## チケット
#363 

## 修正内容
IssueコメントイベントとPRレビューイベントに対する処理を追加
一部PRの番号がundefinedと表示されている不具合の修正